### PR TITLE
run linkchecker simulating the bookshelf layout

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -6,6 +6,15 @@ main() {
 
     linkchecker book
 
+    # now check this as a directory of the bookshelf
+    rm -rf shelf
+    mkdir shelf
+    mv book shelf
+    linkchecker shelf
+
+    mv shelf/book .
+    rmdir shelf
+
     # first (fast) pass: check that examples compile
     for chapter in $(echo src/*); do
         if [ ! -f $chapter/Cargo.toml ]; then


### PR DESCRIPTION
this catches / prevents build errors in the bookshelf repo like
https://travis-ci.org/rust-embedded/bookshelf/builds/433522599