### PR TITLE
Update .cargo/config diff baseline

### DIFF
--- a/src/05-led-roulette/.cargo/config
+++ b/src/05-led-roulette/.cargo/config
@@ -1,6 +1,5 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]

--- a/src/05-led-roulette/the-challenge.md
+++ b/src/05-led-roulette/the-challenge.md
@@ -49,7 +49,6 @@ $ cat .cargo/config
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb" # <-
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 ```

--- a/src/06-hello-world/.cargo/config
+++ b/src/06-hello-world/.cargo/config
@@ -1,6 +1,5 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]

--- a/src/06-hello-world/README.md
+++ b/src/06-hello-world/README.md
@@ -77,11 +77,10 @@ default target in .cargo/config:
 
 ``` diff
  [target.thumbv7em-none-eabihf]
- runner = "arm-none-eabi-gdb"
+ runner = "arm-none-eabi-gdb -q -x openocd.gdb"
  rustflags = [
+   "-C", "linker=rust-lld",
    "-C", "link-arg=-Tlink.x",
-   "-C", "linker=arm-none-eabi-ld",
-   "-Z", "linker-flavor=ld",
  ]
 
 +[build]

--- a/src/06-hello-world/README.md
+++ b/src/06-hello-world/README.md
@@ -79,7 +79,6 @@ default target in .cargo/config:
  [target.thumbv7em-none-eabihf]
  runner = "arm-none-eabi-gdb -q -x openocd.gdb"
  rustflags = [
-   "-C", "linker=rust-lld",
    "-C", "link-arg=-Tlink.x",
  ]
 

--- a/src/07-registers/.cargo/config
+++ b/src/07-registers/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 

--- a/src/08-leds-again/.cargo/config
+++ b/src/08-leds-again/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 

--- a/src/09-clocks-and-timers/.cargo/config
+++ b/src/09-clocks-and-timers/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 

--- a/src/11-usart/.cargo/config
+++ b/src/11-usart/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 

--- a/src/14-i2c/.cargo/config
+++ b/src/14-i2c/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 

--- a/src/15-led-compass/.cargo/config
+++ b/src/15-led-compass/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 

--- a/src/16-punch-o-meter/.cargo/config
+++ b/src/16-punch-o-meter/.cargo/config
@@ -1,7 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
-  "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
 ]
 


### PR DESCRIPTION
The diff in 06-hello-world/README.md for changes to be made to
.cargo/config are based off of an older version of the config file than
what is found in the repository currently.