### PR TITLE
Switch '_ef' reference to 'ef' in GDB session example

### DIFF
--- a/src/07-registers/bad-address.md
+++ b/src/07-registers/bad-address.md
@@ -74,7 +74,7 @@ We can get more information about the exception from the debugger. Let's see:
 `ef` is a snapshot of the program state right before the exception occurred. Let's inspect it:
 
 ```
-(gdb) print/x *_ef
+(gdb) print/x *ef
 $1 = cortex_m_rt::ExceptionFrame {
   r0: 0x48001800,
   r1: 0x48001800,


### PR DESCRIPTION
I see 'ef' used correctly everywhere else in this section. Looks like
this one just got missed in 2a213e70ebb763388cf344d3c678fe42dc7113d8.