### PR TITLE
Fix a couple of typos in Chapter 8 docs

### DIFF
--- a/src/08-leds-again/README.md
+++ b/src/08-leds-again/README.md
@@ -1,7 +1,7 @@
 # LEDs, again
 
 In the last section, I gave you *initialized* (configured) peripherals (I initialized them in
-`aux8::init`). That's why just writing to `BSRR` was enough to control the LEDs. But, peripherals
+`aux7::init`). That's why just writing to `BSRR` was enough to control the LEDs. But, peripherals
 are not *initialized* right after the microcontroller boots.
 
 In this section, you'll have more fun with registers. I won't do any initialization and you'll have

--- a/src/08-leds-again/configuration.md
+++ b/src/08-leds-again/configuration.md
@@ -13,7 +13,7 @@ The register we'll have to deal with is: `MODER`.
 Your task for this section is to further update the starter code to configure the *right* `GPIOE`
 pins as digital outputs. You'll have to:
 
-- Figure out *which* pins you need to configure as digital outupts. (hint: check Section 6.4 LEDs of
+- Figure out *which* pins you need to configure as digital outputs. (hint: check Section 6.4 LEDs of
   the *User Manual* (page 18)).
 - Read the documentation to understand what the bits in the `MODER` register do.
 - Modify the `MODER` register to configure the pins as digital outputs.


### PR DESCRIPTION
* Should reference aux7::init instead of aux8::init when talking about
  previous chapter's code.
* Misspelling of 'output'.