### PR TITLE
Update links moved from japaric to rust-embedded

### DIFF
--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -41,7 +41,7 @@ should work but we have listed the version we have tested.
 
 - [`cargo-binutils`]. Version 0.1.4 or newer.
 
-[`cargo-binutils`]: https://github.com/japaric/cargo-binutils
+[`cargo-binutils`]: https://github.com/rust-embedded/cargo-binutils
 
 - `minicom` on Linux and macOS. Tested version: 2.7. Readers report that `picocom` also works but
   we'll use `minicom` in this text.

--- a/src/README.md
+++ b/src/README.md
@@ -53,8 +53,8 @@ use of the STM32F3DISCOVERY development board.
 The source of this book is in [this repository]. If you encounter any typo or problem with the code
 report it on the [issue tracker].
 
-[this repository]: https://github.com/japaric/discovery
-[issue tracker]: https://github.com/japaric/discovery/issues
+[this repository]: https://github.com/rust-embedded/discovery
+[issue tracker]: https://github.com/rust-embedded/discovery/issues
 
 ## Sponsored by
 

--- a/src/explore.md
+++ b/src/explore.md
@@ -153,7 +153,7 @@ So where to next? There are several options:
 - You could check out the [`embedded-hal`] project which aims to build abstractions (traits) for all
   the embedded I/O functionality commonly found on microcontrollers.
 
-[`embedded-hal`]: https://github.com/japaric/embedded-hal
+[`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
 
 - You could join the [Weekly driver initiative] and help us write generic drivers on top of the
   `embedded-hal` traits and that work for all sorts of platforms (ARM Cortex-M, AVR, MSP430, RISCV,


### PR DESCRIPTION
Clicking these links does forward the browser to the correct GitHub
repository but I thought maybe it would be better to just update the
URLs to the new location of these repositories.