### PR TITLE
A few documentation changes

### DIFF
--- a/src/11-usart/README.md
+++ b/src/11-usart/README.md
@@ -12,8 +12,9 @@ and RX stands for receiver. Transmitter and receiver are relative terms though; 
 transmitter and which line is the receiver depends from which side of the communication you are
 looking at the lines.
 
-We'll be using the pin `PA9` as the microcontroller's TX line and `PA10` as its RX line. IOW, the
-pin `PA9` outputs data onto its wire wheres the pin `PA10` listens for data on its wire.
+We'll be using the pin `PA9` as the microcontroller's TX line and `PA10` as its RX line. In other
+words, the pin `PA9` outputs data onto its wire whereas the pin `PA10` listens for data on its
+wire.
 
 We could have used a different pair of pins as the TX and RX pins. There's a table in page 44 of the
 [Data Sheet] that list all the other possible pins we could have used.

--- a/src/16-punch-o-meter/gravity-is-up.md
+++ b/src/16-punch-o-meter/gravity-is-up.md
@@ -12,7 +12,7 @@ acceleration of the gravity, about `9.8` meters per second squared.
 {{#include src/main.rs}}
 ```
 
-The output of this program with the board sitting still is:
+The output of this program with the board sitting still will be something like:
 
 ``` console
 $ # itmdump console


### PR DESCRIPTION
* I don't see the IOW acronym enough to know what it means without
  looking it up. I thought others might have the same issue so I
  expanded it. In the same sentence I changed what I think was an
  incorrect spelling of "whereas".
* I changed the text describing the itmdump of accelerometer readings
  to indicate that the actual output seen by the user if they run the
  same code won't be exactly as seen here.