### PR TITLE
Link back to bookshelf for other embedded resources

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -56,6 +56,16 @@ report it on the [issue tracker].
 [this repository]: https://github.com/rust-embedded/discovery
 [issue tracker]: https://github.com/rust-embedded/discovery/issues
 
+## Other embedded Rust resources
+
+This Discovery book is just one of several embedded Rust resources provided by the
+[Embedded Working Group]. The full selection can be found at [The Embedded Rust Bookshelf]. This
+includes the list of [Frequently Asked Questions].
+
+[Embedded Working Group]: https://github.com/rust-embedded/wg
+[The Embedded Rust Bookshelf]: https://rust-embedded.github.io/bookshelf/
+[Frequently Asked Questions]: https://rust-embedded.github.io/bookshelf/faq.html
+
 ## Sponsored by
 
 <p align="center">


### PR DESCRIPTION
This is my initial attempt to address issue #129 opened by @adamgreig
to have links back to the bookshelf added to the front page. I am
not sure if this is what you were looking for but I thought I would
give it a try. Let me know what you think.