### PR TITLE
Update bookshelf URLs to new location

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -63,8 +63,8 @@ This Discovery book is just one of several embedded Rust resources provided by t
 includes the list of [Frequently Asked Questions].
 
 [Embedded Working Group]: https://github.com/rust-embedded/wg
-[The Embedded Rust Bookshelf]: https://rust-embedded.github.io/bookshelf/
-[Frequently Asked Questions]: https://rust-embedded.github.io/bookshelf/faq.html
+[The Embedded Rust Bookshelf]: https://docs.rust-embedded.org
+[Frequently Asked Questions]: https://docs.rust-embedded.org/faq.html
 
 ## Sponsored by
 


### PR DESCRIPTION
Documentation was recently moved to docs.rust-embedded.org and the old
links on this page now result in 404 errors.