### PR TITLE
Update gdb instructions for Ubuntu 18.04+

### DIFF
--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -29,7 +29,8 @@ $ sudo pacman -S \
   arm-none-eabi-gdb \
   minicom
 ```
-`openocd` is not availabie in the official Arch repositories, but can be installed from the [AUR](https://aur.archlinux.org/packages/openocd/) or can be compiled from source as follows:
+
+`openocd` is not available in the official Arch repositories, but can be installed from the [AUR](https://aur.archlinux.org/packages/openocd/) or can be compiled from source as follows:
 
 ``` console
 git clone git://git.code.sf.net/p/openocd/code openocd-code

--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -4,7 +4,34 @@ Here are the installation commands for a few Linux distributions.
 
 ## REQUIRED packages
 
-- Ubuntu 16.04 or newer / Debian Jessie or newer
+- Ubuntu 18.04 or newer / Debian stretch or newer
+
+> **NOTE** `gdb-multiarch` is the GDB command you'll use to debug your ARM
+> Cortex-M programs
+
+<!-- Debian stretch -->
+<!-- GDB 7.12 -->
+<!-- OpenOCD 0.9.0 -->
+
+<!-- Ubuntu 18.04 -->
+<!-- GDB 8.1 -->
+<!-- OpenOCD 0.10.0 -->
+
+``` console
+$ sudo apt-get install \
+  gdb-multiarch \
+  minicom \
+  openocd
+```
+
+- Ubuntu 14.04 and 16.04
+
+> **NOTE** `arm-none-eabi-gdb` is the GDB command you'll use to debug your ARM
+> Cortex-M programs
+
+<!-- Ubuntu 14.04 -->
+<!-- GDB 7.6 -->
+<!-- OpenOCD 0.7.0 -->
 
 ``` console
 $ sudo apt-get install \
@@ -15,6 +42,9 @@ $ sudo apt-get install \
 
 - Fedora 23 or newer
 
+> **NOTE** `arm-none-eabi-gdb` is the GDB command you'll use to debug your ARM
+> Cortex-M programs
+
 ``` console
 $ sudo dnf install \
   arm-none-eabi-gdb \
@@ -23,6 +53,9 @@ $ sudo dnf install \
 ```
 
 - Arch Linux
+
+> **NOTE** `arm-none-eabi-gdb` is the GDB command you'll use to debug ARM
+> Cortex-M programs
 
 ``` console
 $ sudo pacman -S \

--- a/src/05-led-roulette/flash-it.md
+++ b/src/05-led-roulette/flash-it.md
@@ -82,10 +82,14 @@ available.
 I mentioned that OpenOCD provides a GDB server so let's connect to that right now:
 
 ``` console
-$ arm-none-eabi-gdb -q target/thumbv7em-none-eabihf/debug/led-roulette
+$ <gdb> -q target/thumbv7em-none-eabihf/debug/led-roulette
 Reading symbols from target/thumbv7em-none-eabihf/debug/led-roulette...done.
 (gdb)
 ```
+
+**NOTE**: `<gdb>` represents a GDB program capable of debugging ARM binaries.
+This could be `arm-none-eabi-gdb`, `gdb-multiarch` or `gdb` depending on your
+system -- you may have to try all three.
 
 This only opens a GDB shell. To actually connect to the OpenOCD GDB server, use the following
 command within the GDB shell:


### PR DESCRIPTION
I recently had the pleasure of working my way through the Discovery book. The only stumbling block was that I couldn't find the `gdb-arm-none-eabi` package on Ubuntu 18.04/18.10. I later found that The Embedded Rust Book had more up to date instructions on this part. This PR copies those improvements from `book` to `discovery`.

This should fix #91.