### PR TITLE
Adding break to clear buffer.

### DIFF
--- a/src/11-usart/my-solution.md
+++ b/src/11-usart/my-solution.md
@@ -40,6 +40,8 @@ fn main() -> ! {
                     while usart1.isr.read().txe().bit_is_clear() {}
                     usart1.tdr.write(|w| w.tdr().bits(u16::from(*byte)));
                 }
+
+                break;
             }
         }
     }


### PR DESCRIPTION
Either a `break` or `buffer.clear()` is needed here to ensure the buffer is properly cleared between each server response.