### PR TITLE
Fix required itmdump version to match install steps

### DIFF
--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -32,7 +32,7 @@ should work but we have listed the version we have tested.
 
 - Rust 1.31 or a newer toolchain.
 
-- [`itmdump`] v0.2.1
+- [`itmdump`] v0.3.1
 
 - OpenOCD >=0.8. Tested versions: v0.9.0 and v0.10.0
 


### PR DESCRIPTION
Lower in the steps `0.3.1` is used, so I presume this is the correct version.