### PR TITLE
Chapter 7: Breakpoint should be set on HardFault

### DIFF
--- a/src/07-registers/openocd.gdb
+++ b/src/07-registers/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue


### PR DESCRIPTION
UserHardFault renamed to HardFault in cortex-m-rt:
https://github.com/rust-embedded/cortex-m-rt/commit/790e42477ca21d6d0a07270049c3747c7c316f4b