### PR TITLE
Make `itmdump` more visible (second try)

### DIFF
--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -32,7 +32,7 @@ should work but we have listed the version we have tested.
 
 - Rust 1.31 or a newer toolchain.
 
-- [`itmdump`] v0.3.1
+- [`itmdump`] v0.3.1 (cargo install itm)
 
 - OpenOCD >=0.8. Tested versions: v0.9.0 and v0.10.0
 

--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -32,7 +32,7 @@ should work but we have listed the version we have tested.
 
 - Rust 1.31 or a newer toolchain.
 
-- [`itmdump`] v0.3.1 (cargo install itm)
+- [`itmdump`] v0.3.1 (`cargo install itm`)
 
 - OpenOCD >=0.8. Tested versions: v0.9.0 and v0.10.0
 


### PR DESCRIPTION
The `itm` is in the book formatted as code. Therefore, it is not intuitive to click on the link and to be redirected to the cargo page. In addition, the crate doesn't show how to get it up & running.

I suggest to add a note with `cargo install itm` next to the `itmdump` link.