### PR TITLE
Update macOS setup instructions for ARM toolchain.

### DIFF
--- a/src/03-setup/macos.md
+++ b/src/03-setup/macos.md
@@ -5,13 +5,13 @@ All the tools can be install using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` console
-$ brew cask install gcc-arm-embedded
+$ # Arm GCC toolchain
+$ brew tap ArmMbed/homebrew-formulae
+$ brew install arm-none-eabi-gcc
 
+$ # Minicom and OpenOCD
 $ brew install minicom openocd
 ```
-
-If the `brew cask` command doesn't work (`Error: Unknown command: cask`), then run `brew tap
-Caskroom/tap` first and try again.
 
 That's all! Go to the [next section].
 


### PR DESCRIPTION
The `gcc-arm-embedded` was deleted from the cask (pease see #167) and the setup command won't work. Closest working solution seems to be using formulae from [ARMmbed/homebrew-formulae](https://github.com/armmbed/homebrew-formulae).