### PR TITLE
Requirements: USB cables need data transfer

### DIFF
--- a/src/02-requirements/README.md
+++ b/src/02-requirements/README.md
@@ -55,7 +55,8 @@ cheaper for you to get)
 </p>
 
 - Two mini-B USB cables. One is required to make the STM32F3DISCOVERY board work. The other is only
-  required if you have the Serial <-> USB module.
+  required if you have the Serial <-> USB module. Make sure that the cables both
+  support data transfer as some cables only support charging devices.
 
 <p align="center">
 <img title="mini-B USB cable" src="../assets/usb-cable.jpg">


### PR DESCRIPTION
I was getting started with the discovery book and still had two old
unmarked Mini USB cables laying around. Unfortunately none of them
were working.

I don't know too much about the USB standards, but one reason
may be that these cables only support charging without data transfer.

I think it would be good to mention this here, if people go out and buy
new cables.