### PR TITLE
Feat: add custom formatting for images

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,3 +3,6 @@ title = "Discovery"
 description = "Discover the world of microcontrollers through Rust"
 author = "Rust Embedded Resources Team"
 language = "en"
+
+[output.html]
+additional-css = ["custom.css"]

--- a/custom.css
+++ b/custom.css
@@ -1,0 +1,6 @@
+/* Add this style to the image if it's unreadable
+when the dark theme is applied */
+img.white_bg {
+	background-color: white;
+	padding: 1em;
+}

--- a/src/05-led-roulette/the-challenge.md
+++ b/src/05-led-roulette/the-challenge.md
@@ -12,7 +12,7 @@ Here's the GIF again:
 Also, this may help:
 
 <p align="center">
-<img src="../assets/timing-diagram.png">
+<img class="white_bg" src="../assets/timing-diagram.png">
 </p>
 
 This is a timing diagram. It indicates which LED is on at any given instant of time and for how long

--- a/src/07-registers/README.md
+++ b/src/07-registers/README.md
@@ -28,7 +28,7 @@ connected to LEDs. An LED, a Light Emitting Diode, will only emit light when vol
 it with a certain polarity.
 
 <p align="center">
-<img height=180 title="LED circuit" src="https://upload.wikimedia.org/wikipedia/commons/c/c9/LED_circuit.svg">
+<img class="white_bg" height=180 title="LED circuit" src="https://upload.wikimedia.org/wikipedia/commons/c/c9/LED_circuit.svg">
 </p>
 
 Luckily for us, the microcontroller's pins are connected to the LEDs with the right polarity. All

--- a/src/14-i2c/README.md
+++ b/src/14-i2c/README.md
@@ -19,7 +19,7 @@ uses two lines to exchange data: a data line (SDA) and a clock line (SCL). Becau
 used to synchronize the communication, this is a *synchronous* protocol.
 
 <p align="center">
-<img height=180 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/3/3e/I2C.svg">
+<img class="white_bg" height=180 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/3/3e/I2C.svg">
 </p>
 
 This protocol uses a *master* *slave* model where the master is the device that *starts* and

--- a/src/14-i2c/the-general-protocol.md
+++ b/src/14-i2c/the-general-protocol.md
@@ -8,7 +8,7 @@ communication between several devices. Let's see how it works using examples:
 If the master wants to send data to the slave:
 
 <p align="center">
-  <img height=180 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/3/3e/I2C.svg">
+  <img class="white_bg" height=180 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/3/3e/I2C.svg">
 </p>
 
 1. Master: Broadcast START
@@ -27,7 +27,7 @@ If the master wants to send data to the slave:
 If the master wants to read data from the slave:
 
 <p align="center">
-<img height=180 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/3/3e/I2C.svg">
+<img class="white_bg" height=180 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/3/3e/I2C.svg">
 </p>
 
 1. M: Broadcast START

--- a/src/15-led-compass/take-1.md
+++ b/src/15-led-compass/take-1.md
@@ -21,7 +21,7 @@ If we only looked at the signs of the X and Y components we could determine to w
 magnetic field belongs to.
 
 <p align="center">
-<img title="Quadrants" src="../assets/quadrants.png">
+<img class="white_bg" title="Quadrants" src="../assets/quadrants.png">
 </p>
 
 In the previous example, the magnetic field was in the first quadrant (x and y were positive) and it

--- a/src/15-led-compass/take-2.md
+++ b/src/15-led-compass/take-2.md
@@ -7,7 +7,7 @@ We'll use the `atan2` function. This function returns an angle in the `-PI` to `
 graphic below shows how this angle is measured:
 
 <p align="center">
-<img title="atan2" src="https://upload.wikimedia.org/wikipedia/commons/0/03/Atan2_60.svg">
+<img class="white_bg" title="atan2" src="https://upload.wikimedia.org/wikipedia/commons/0/03/Atan2_60.svg">
 </p>
 
 Although not explicitly shown in this graph the X axis points to the right and the Y axis points up.


### PR DESCRIPTION
Some images with alpha channel, are unreadable when a dark theme is applied. This commit adds a custom image style, named `white_bg`, that can be used to fix this issue.

The style is very simple, and adds two features:
- white background,
- a small padding around the image