### PR TITLE
Update CI install to use latest mdbook, reverting 09753a1

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -12,8 +12,7 @@ main() {
         sh -s -- \
            --force \
            --git rust-lang/mdbook \
-           --tag $tag \
-           --target x86_64-unknown-linux-musl
+           --tag $tag
 
     rustup target add thumbv7em-none-eabihf
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,17 +1,17 @@
 set -euxo pipefail
 
 main() {
-    # install latest mdbook v0.2.x release
-    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/rust-lang-nursery/mdbook \
+    local tag=$(git ls-remote --tags --refs --exit-code \
+                    https://github.com/rust-lang/mdbook \
                     | cut -d/ -f3 \
-                    | grep -E '^v0.2.[0-9]+$' \
+                    | grep -E '^v[0-9\.]+$' \
                     | sort --version-sort \
                     | tail -n1)
-    local tag="v0.2.1"
+
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \
            --force \
-           --git rust-lang-nursery/mdBook \
+           --git rust-lang/mdbook \
            --tag $tag \
            --target x86_64-unknown-linux-musl
 


### PR DESCRIPTION
Ref #136 

Closes #137 

`ci/install.sh` is updated based on [book's copy](https://github.com/rust-embedded/book/blob/master/ci/install.sh), but preserving the rustup line and target specification.