### PR TITLE
Add knowledge requirement for hex and bitwise operations.

### DIFF
--- a/src/02-requirements/README.md
+++ b/src/02-requirements/README.md
@@ -1,12 +1,29 @@
 # Hardware/knowledge requirements
 
-The only knowledge requirement to read this book is to know *some* Rust. It's
+The primary knowledge requirement to read this book is to know *some* Rust. It's
 hard for me to quantify *some* but at least I can tell you that you don't need
 to fully grok generics but you do need to know how to *use* closures. You also
 need to be familiar with the idioms of the [2018 edition], in particular with
 the fact that `extern crate` is not necessary in the 2018 edition.
 
 [2018 edition]: https://rust-lang-nursery.github.io/edition-guide/
+
+Due to the nature of embedded programming, it will also be extremely helpful to
+understand how binary and hexadecimal representations of values work, as well
+as the use of some bitwise operators. For example, it would be useful to
+understand how the following program produces its output.
+
+```rust
+fn main() {
+    let a = 0x4000_0000 + 0xa2;
+
+    // Use of the bit shift "<<" operation.
+    let b = 1 << 5;
+
+    // {:X} will format values as hexadecimal
+    println!("{:X}: {:X}", a, b);
+}
+```
 
 Also, to follow this material you'll need the following hardware:
 


### PR DESCRIPTION
Was wondering if this small addition to the "knowledge" requirements would be useful to add. I think having a full-on tutorial (even something in the appendix) for these would be a bit out of scope for this tutorial, but sometimes it helps to just give something a name for people to google later.

I'm not familiar with how technical book layouts like this works; is there some way that the code sample in this PR needs to be put into another file (e.g., so that there can be an automated check that the code still compiles), or would that only need to be reserved for larger, more important code samples?