### PR TITLE
Removed overwhelming info, added context to "Meet your Hardware"

### DIFF
--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -11,6 +11,7 @@ Let's get familiar with the hardware we'll be working with.
 We'll refer to this board as "F3" throughout this book. Here are some of the
 many components on the board:
 
+- A [microcontroller].
 - A number of LEDs, including the eight aligned in a "compass" formation.
 - Two buttons.
 - Two USB ports.
@@ -18,17 +19,17 @@ many components on the board:
 - A [magnetometer].
 - A [gyroscope].
 
+[microcontroller]: https://en.wikipedia.org/wiki/Microcontroller
 [accelerometer]: https://en.wikipedia.org/wiki/Accelerometer
 [magnetometer]: https://en.wikipedia.org/wiki/Magnetometer
 [gyroscope]: https://en.wikipedia.org/wiki/Gyroscope
 
-Of these components, the most important is the [microcontroller] (sometimes
+Of these components, the most important is the microcontroller (sometimes
 shortened to "MCU" for "microcontroller unit"), which is the large black square
 sitting in the center of your board. The MCU is what runs your code. You might
 sometimes read about "programming a board", when in reality what we are doing
 is programming the MCU that is installed on the board.
 
-[microcontroller]: https://en.wikipedia.org/wiki/Microcontroller
 
 ## STM32F303VCT6 (the "STM32F3")
 

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -42,17 +42,20 @@ current flows through a circuit. By enabling or disabling electrical current to
 flow through a specific pin, an LED attached to that pin (via the traces) can
 be turned on and off.
 
-Part numbers of components can often give us information about the part. In the
-case of our MCU (with part number `STM32F303VCT6`), the `ST` at the start
-hints to us that this is manufactured by [ST Microelectronics]. Each
-manufacturer uses a different part numbering scheme, but with some research we
-can also determine that the `M32` implies that this is specifically an
-Arm®-based 32-bit microcontroller, and the `F3` indicates that the
-microcontroller is based on the Cortex®-M4. The rest of the part number
-provides more specifics (e.g., extra features, RAM size), and aren't as
-important to us right now.
+Each manufacturer uses a different part numbering scheme, but many will allow
+you to determine information about a component simply by looking at the part
+number. Looking at our MCU's part number (`STM32F303VCT6`), the `ST` at the
+front hints to us that this is a part manufactured by [ST Microelectronics].
+Searching through [ST's marketing materials] we can also learn the following:
 
 [ST Microelectronics]: https://st.com/
+[ST's marketing materials]: https://www.st.com/en/microcontrollers-microprocessors/stm32-mainstream-mcus.html
+
+- The `M32` represents that this is an Arm®-based 32-bit microcontroller.
+- The `F3` represents that the MCU is from ST's "STM32F3" series. This is a
+  series of MCUs based on the Cortex®-M4 processor design.
+- The remainder of the part number goes into more details about things like
+  extra features and RAM size, which at this point we're less concerned about.
 
 > ### Arm? Cortex-M4?
 >

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -43,10 +43,10 @@ flow through a specific pin, an LED attached to that pin (via the traces) can
 be turned on and off.
 
 Part numbers of components can often give us information about the part. In the
-case of our MCU (with part number `STM32F303VCT6`), the `STM` at the start
+case of our MCU (with part number `STM32F303VCT6`), the `ST` at the start
 hints to us that this is manufactured by [ST Microelectronics]. Each
 manufacturer uses a different part numbering scheme, but with some research we
-can also determine that the `32` implies that this is specifically an
+can also determine that the `M32` implies that this is specifically an
 Arm®-based 32-bit microcontroller, and the `F3` indicates that the
 microcontroller is based on the Cortex®-M4. The rest of the part number
 provides more specifics (e.g., extra features, RAM size), and aren't as

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -30,7 +30,6 @@ sitting in the center of your board. The MCU is what runs your code. You might
 sometimes read about "programming a board", when in reality what we are doing
 is programming the MCU that is installed on the board.
 
-
 ## STM32F303VCT6 (the "STM32F3")
 
 Since the MCU is so important, let's take a closer look at the one sitting on our board.
@@ -38,14 +37,14 @@ Since the MCU is so important, let's take a closer look at the one sitting on ou
 Our MCU is surrounded by 100 tiny metal **pins**. These pins are connected to
 **traces**, the little "roads" that act as the wires connecting components
 together on the board. The MCU can dynamically alter the electrical properties
-of the pins. This works similar to a lightswitch altering how electrical
+of the pins. This works similar to a light switch altering how electrical
 current flows through a circuit. By enabling or disabling electrical current to
 flow through a specific pin, an LED attached to that pin (via the traces) can
 be turned on and off.
 
 Part numbers of components can often give us information about the part. In the
 case of our MCU (with part number `STM32F303VCT6`), the `STM` at the start
-hints to use that this is manufactured by [ST Microelectronics]. Each
+hints to us that this is manufactured by [ST Microelectronics]. Each
 manufacturer uses a different part numbering scheme, but with some research we
 can also determine that the `32` implies that this is specifically an
 Arm®-based 32-bit microcontroller, and the `F3` indicates that the

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -43,13 +43,15 @@ current flows through a circuit. By enabling or disabling electrical current to
 flow through a specific pin, an LED attached to that pin (via the traces) can
 be turned on and off.
 
-By looking at the part number and doing some research, we can learn more
-information about electronic components. The part number of our microcontroller
-starts with `STM32`, which indicates that it was manufactured by [ST
-Microelectronics]. It also lets us know that this is an Arm®-based 32-bit
-microcontroller. The `F3` in the part number indicates that the microcontroller
-is based on the Cortex®-M4. The rest of the part number provides more specifics
-(e.g., extra features, RAM size), and aren't as important to us right now.
+Part numbers of components can often give us information about the part. In the
+case of our MCU (with part number `STM32F303VCT6`), the `STM` at the start
+hints to use that this is manufactured by [ST Microelectronics]. Each
+manufacturer uses a different part numbering scheme, but with some research we
+can also determine that the `32` implies that this is specifically an
+Arm®-based 32-bit microcontroller, and the `F3` indicates that the
+microcontroller is based on the Cortex®-M4. The rest of the part number
+provides more specifics (e.g., extra features, RAM size), and aren't as
+important to us right now.
 
 [ST Microelectronics]: https://st.com/
 

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -8,40 +8,79 @@ Let's get familiar with the hardware we'll be working with.
 <img title="F3" src="../assets/f3.jpg">
 </p>
 
-We'll refer to this board as "F3" throughout this book.
+We'll refer to this board as "F3" throughout this book. Here are some of the
+many components on the board:
 
-What does this board contain?
-
-- A STM32F303VCT6 microcontroller. This microcontroller has
-  - A single core ARM Cortex-M4F processor with hardware support for single precision floating point
-    operations and a maximum clock frequency of 72 MHz.
-
-  - 256 KiB of "Flash" memory. (1 KiB = 10**24** bytes)
-
-  - 48 KiB of RAM.
-
-  - many "peripherals": timers, GPIO, I2C, SPI, USART, etc.
-
-  - lots of "pins" that are exposed in the two lateral "headers".
-
-  - **IMPORTANT** This microcontroller operates at (around) 3.3V.
-
-- An [accelerometer] and a [magnetometer][] (in a single package).
+- A number of LEDs, including the eight aligned in a "compass" formation.
+- Two buttons.
+- Two USB ports.
+- An [accelerometer].
+- A [magnetometer].
+- A [gyroscope].
 
 [accelerometer]: https://en.wikipedia.org/wiki/Accelerometer
 [magnetometer]: https://en.wikipedia.org/wiki/Magnetometer
-
-- A [gyroscope].
-
 [gyroscope]: https://en.wikipedia.org/wiki/Gyroscope
 
-- 8 user LEDs arranged in the shape of a compass
+Of these components, the most important is the [microcontroller] (sometimes
+shortened to "MCU" for "microcontroller unit"), which is the large black square
+sitting in the center of your board. The MCU is what runs your code. You might
+sometimes read about "programming a board", when in reality what we are doing
+is programming the MCU that is installed on the board.
 
-- A second microcontroller: a STM32F103CBT. This microcontroller is actually part of an on-board
-  programmer and debugger named ST-LINK and is connected to the USB port named "USB ST-LINK".
+[microcontroller]: https://en.wikipedia.org/wiki/Microcontroller
 
-- There's a second USB port, labeled "USB USER" that is connected to the main microcontroller, the
-  STM32F303VCT6, and can be used in applications.
+## STM32F303VCT6 (the "STM32F3")
+
+Since the MCU is so important, let's take a closer look at the one sitting on our board.
+
+Our MCU is surrounded by 100 tiny metal **pins**. These pins are connected to
+**tracings**, the little "roads" that act as the wires connecting components
+together on the board. The MCU can dynamically alter the electrical properties
+of the pins. This works similar to a lightswitch altering how electrical
+current flows through a circuit. By enabling or disabling electrical current to
+flow through a specific pin, an LED attached to that pin (via the tracing) can
+be turned on and off.
+
+By looking at the part number and doing some research, we can learn more
+information about electronic components. The part number of our microcontroller
+starts with `STM32`, which indicates that it was manufactured by [ST
+Microelectronics]. It also lets us know that this is an Arm®-based 32-bit
+microcontroller. The `F3` in the part number indicates that the microcontroller
+is based on the Cortex®-M4. The rest of the part number provides more specifics
+(e.g., extra features, RAM size), and aren't as important to us right now.
+
+[ST Microelectronics]: https://st.com/
+
+> ### Arm? Cortex-M4?
+>
+> If our chip is manufactured by ST, then who is Arm? And if our chip is the
+> STM32F3, what is the Cortex-M4?
+>
+> You might be surprised to hear that while "Arm-based" chips are quite
+> popular, the company behind the "Arm" trademark ([Arm Holdings][]) doesn't
+> actually manuafacture chips for purchase. Instead, their primary business
+> model is to just *design* parts of chips. They will then license those designs to
+> manufacturers, who will in turn implement the designs (perhaps with some of
+> their own tweaks) in the form of physical hardware that can then be sold.
+> Arm's strategy here is different from companies like Intel, which both
+> designs *and* manufactures their chips.
+>
+> Arm licenses a bunch of different designs. Their "Cortex-M" family of designs
+> are mainly used as the core in microcontrollers. For example, the Cortex-M0
+> is designed for low cost and low power usage. The Cortex-M7 is higher cost,
+> but with more features and performance.  The core of our STM32F3 is based on
+> the Cortex-M4, which is in the middle: more features and performance than the
+> Cortex-M0, but less expensive than the Cortex-M7.
+>
+> Luckily, you don't need to know too much about different types of processors
+> or Cortex designs for the sake of this book. However, you are hopefully now a
+> bit more knowledgeable about the terminology of your device. While you are
+> working specifically with an STM32F3, you might find yourself reading
+> documentation and using tools for Cortex-M-based chips, as the STM32F3 is
+> based on a Cortex-M design.
+
+[Arm Holdings]: https://www.arm.com/
 
 ## The Serial module
 

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -74,7 +74,7 @@ Searching through [ST's marketing materials] we can also learn the following:
 > Arm licenses a bunch of different designs. Their "Cortex-M" family of designs
 > are mainly used as the core in microcontrollers. For example, the Cortex-M0
 > is designed for low cost and low power usage. The Cortex-M7 is higher cost,
-> but with more features and performance.  The core of our STM32F3 is based on
+> but with more features and performance. The core of our STM32F3 is based on
 > the Cortex-M4, which is in the middle: more features and performance than the
 > Cortex-M0, but less expensive than the Cortex-M7.
 >

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -35,11 +35,11 @@ is programming the MCU that is installed on the board.
 Since the MCU is so important, let's take a closer look at the one sitting on our board.
 
 Our MCU is surrounded by 100 tiny metal **pins**. These pins are connected to
-**tracings**, the little "roads" that act as the wires connecting components
+**traces**, the little "roads" that act as the wires connecting components
 together on the board. The MCU can dynamically alter the electrical properties
 of the pins. This works similar to a lightswitch altering how electrical
 current flows through a circuit. By enabling or disabling electrical current to
-flow through a specific pin, an LED attached to that pin (via the tracing) can
+flow through a specific pin, an LED attached to that pin (via the traces) can
 be turned on and off.
 
 By looking at the part number and doing some research, we can learn more
@@ -59,7 +59,7 @@ is based on the Cortex®-M4. The rest of the part number provides more specifics
 >
 > You might be surprised to hear that while "Arm-based" chips are quite
 > popular, the company behind the "Arm" trademark ([Arm Holdings][]) doesn't
-> actually manuafacture chips for purchase. Instead, their primary business
+> actually manufacture chips for purchase. Instead, their primary business
 > model is to just *design* parts of chips. They will then license those designs to
 > manufacturers, who will in turn implement the designs (perhaps with some of
 > their own tweaks) in the form of physical hardware that can then be sold.


### PR DESCRIPTION
In the first in a series of changes I'm proposing to try to help resolve issue #199, this changes the book's "Meet Your Hardware" in a few ways.

## Clearly delineate the board from the microcontroller.

While technically the original bullet points listed that the microcontroller was one of the components of the board, this hopefully makes a bit more clear that really they are two completely separate entities. This should especially help in Chapter 7 when readers are asked to jump between different reference manuals; understanding when to look at the reference manual of the board vs the microcontroller requires a solid understanding of the difference between these two products.

Also, given the book's expectation that the user has no previous knowledge of embedded development, I felt that listing specs (like RAM and Flash) probably only end up confusing them, as there is probably limited understanding of why they would need to know this information. Why is it important that the user knows that the microcontroller operates at 3.3v we're going to just plug in a USB cable and let the on-board voltage regulator do its job?

## Describe how "Arm" comes into all of this.

The book assumes that users have no familiarity with embedded development. I had _some_ experience (from the Arduino world) before working on a Feather M0, but still didn't understand what an "Arm processor" was, or why I was running tooling specifically made for Cortex-M chips. Hopefully this text (made as an aside so as to be easily skippable by those who do understand this delineation) can be useful.