### PR TITLE
Batch of styling and formatting changes

### DIFF
--- a/src/01-background/README.md
+++ b/src/01-background/README.md
@@ -2,7 +2,7 @@
 
 ## What's a microcontroller?
 
-A microcontroller is a *system* on a chip. Whereas your laptop is made up of several discrete
+A microcontroller is a *system* on a chip. Whereas your computer is made up of several discrete
 components: a processor, RAM sticks, a hard drive, an ethernet port, etc.; a microcontroller has all
 those components built into a single "chip" or package. This makes it possible to build systems with
 minimal part count.

--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -1,7 +1,7 @@
 # Setting up a development environment
 
 Dealing with microcontrollers involves several tools as we'll be dealing with an architecture
-different than your laptop's and we'll have to run and debug programs on a "remote" device.
+different than your computer's and we'll have to run and debug programs on a "remote" device.
 
 ## Documentation
 
@@ -50,7 +50,7 @@ should work but we have listed the version we have tested.
 
 [`itmdump`]: https://crates.io/crates/itm
 
-If your laptop has Bluetooth functionality and you have the Bluetooth module, you can additionally
+If your computer has Bluetooth functionality and you have the Bluetooth module, you can additionally
 install these tools to play with the Bluetooth module. All these are optional:
 
 - Linux, only if you don't have a Bluetooth manager application like Blueman.

--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -149,7 +149,7 @@ Then reload the udev rules with:
 $ sudo udevadm control --reload-rules
 ```
 
-If you had any board plugged to your laptop, unplug them and then plug them in again.
+If you had any board plugged to your computer, unplug them and then plug them in again.
 
 Now, go to the [next section].
 

--- a/src/03-setup/verify.md
+++ b/src/03-setup/verify.md
@@ -6,7 +6,7 @@ Let's verify that all the tools were installed correctly.
 
 ### Verify permissions
 
-Connect the F3 to your laptop using an USB cable. Be sure to connect the cable to the "USB ST-LINK"
+Connect the F3 to your computer using an USB cable. Be sure to connect the cable to the "USB ST-LINK"
 port, the USB port in the center of the edge of the board.
 
 The F3 should now appear as a USB device (file) in `/dev/bus/usb`. Let's find out how it got
@@ -57,7 +57,7 @@ As before, the permissions should be `crw-rw-rw-`.
 
 ### First OpenOCD connection
 
-First, connect the F3 to your laptop using an USB cable. Connect the cable to the USB port in the
+First, connect the F3 to your computer using an USB cable. Connect the cable to the USB port in the
 center of edge of the board, the one that's labeled "USB ST-LINK".
 
 Two *red* LEDs should turn on right after connecting the USB cable to the board.

--- a/src/04-meet-your-hardware/README.md
+++ b/src/04-meet-your-hardware/README.md
@@ -94,8 +94,8 @@ Searching through [ST's marketing materials] we can also learn the following:
 </p>
 
 If you have an older revision of the discovery board, you can use this module to
-exchange data between the microcontroller in the F3 and your laptop. This module
-will be connected to your laptop using an USB cable. I won't say more at this
+exchange data between the microcontroller in the F3 and your computer. This module
+will be connected to your computer using an USB cable. I won't say more at this
 point.
 
 If you have a newer release of the board then you don't need this module. The

--- a/src/05-led-roulette/build-it.md
+++ b/src/05-led-roulette/build-it.md
@@ -1,7 +1,7 @@
 # Build it
 
 The first step is to build our "binary" crate. Because the microcontroller has a different
-architecture than your laptop we'll have to cross compile. Cross compiling in Rust land is as simple
+architecture than your computer we'll have to cross compile. Cross compiling in Rust land is as simple
 as passing an extra `--target` flag to `rustc`or Cargo. The complicated part is figuring out the
 argument of that flag: the *name* of the target.
 

--- a/src/05-led-roulette/flash-it.md
+++ b/src/05-led-roulette/flash-it.md
@@ -11,7 +11,7 @@ Onto the actual flashing. First thing we need is to do is launch OpenOCD. We did
 previous section but this time we'll run the command inside a temporary directory (`/tmp` on *nix;
 `%TEMP%` on Windows).
 
-Make sure the F3 is connected to your laptop and run the following commands on a new terminal.
+Make sure the F3 is connected to your computer and run the following commands on a new terminal.
 
 ``` console
 $ # *nix
@@ -41,7 +41,7 @@ STMicroelectronics decided to call it). This ST-LINK is connected to the target 
 using a Serial Wire Debug (SWD) interface (this interface is an ARM standard so you'll run into it
 when dealing with other Cortex-M based microcontrollers). This SWD interface can be used to flash
 and debug a microcontroller. The ST-LINK is connected to the "USB ST-LINK" port and will appear as
-a USB device when you connect the F3 to your laptop.
+a USB device when you connect the F3 to your computer.
 
 <p align="center">
 <img height=640 title="On-board ST-LINK" src="../assets/st-link.png">

--- a/src/05-led-roulette/flash-it.md
+++ b/src/05-led-roulette/flash-it.md
@@ -8,7 +8,7 @@ By this I mean that there's nothing else running on the microcontroller: no OS, 
 nothing. `led-roulette` has full control over the device.
 
 Onto the actual flashing. First thing we need is to do is launch OpenOCD. We did that in the
-previous section but this time we'll run the command inside a temporary directory (`/tmp` on *nix;
+previous section but this time we'll run the command inside a temporary directory (`/tmp` on \*nix;
 `%TEMP%` on Windows).
 
 Make sure the F3 is connected to your computer and run the following commands on a new terminal.

--- a/src/06-hello-world/README.md
+++ b/src/06-hello-world/README.md
@@ -19,7 +19,7 @@ Just a little more of helpful magic before we start doing low level stuff.
 
 Blinking an LED is like the "Hello, world" of the embedded world.
 
-But in this section, we'll run a proper "Hello, world" program that prints stuff to your laptop
+But in this section, we'll run a proper "Hello, world" program that prints stuff to your computer
 console.
 
 Go to the `06-hello-world` directory. There's some starter code in it:
@@ -70,7 +70,7 @@ $ itmdump -F -f itm.txt
 
 This command will block as `itmdump` is now watching the `itm.txt` file. Leave this terminal open.
 
-Make sure that F3 is connected to your laptop. Open another terminal from `/tmp` directory (on Windows `%TEMP%`) to launch OpenOCD similar as described in chapter [First OpenOCD connection].
+Make sure that F3 is connected to your computer. Open another terminal from `/tmp` directory (on Windows `%TEMP%`) to launch OpenOCD similar as described in chapter [First OpenOCD connection].
 
 [First OpenOCD connection]: ../03-setup/verify.html#first-openocd-connection
 

--- a/src/06-hello-world/README.md
+++ b/src/06-hello-world/README.md
@@ -48,7 +48,7 @@ You should have already installed the `itmdump` program during the [installation
 
 [installation chapter]: ../03-setup/index.html#itmdump
 
-In a new terminal, run this command inside the `/tmp` directory, if you are using a *nix OS, or from
+In a new terminal, run this command inside the `/tmp` directory, if you are using a \*nix OS, or from
 within the `%TEMP%` directory, if you are running Windows. This should be the same directory from
 where you are running OpenOCD.
 

--- a/src/10-serial-communication/README.md
+++ b/src/10-serial-communication/README.md
@@ -7,7 +7,7 @@
 </a>
 
 <p align="center">
-<em>This is what we'll be using. I hope your laptop has one!</em>
+<em>This is what we'll be using. I hope your computer has one!</em>
 </p>
 
 Nah, don't worry. This connector, the DE-9, went out of fashion on PCs quite some time ago; it got
@@ -21,9 +21,9 @@ signal. Instead both parties must agree on how fast data will be sent along the 
 communication occurs. This protocol allows *duplex* communication as data can be sent from A to B
 and from B to A simultaneously.
 
-We'll be using this protocol to exchange data between the microcontroller and your laptop. In
+We'll be using this protocol to exchange data between the microcontroller and your computer. In
 contrast to the ITM protocol we have used before, with the serial communication protocol you can
-send data from your laptop to the microcontroller.
+send data from your computer to the microcontroller.
 
 The next practical question you probably want to ask is: How fast can we send data through this
 protocol?
@@ -38,10 +38,10 @@ one frame carries a byte of data that results in a data rate of 11.52 KB/s. In p
 rate will probably be lower because of processing times on the slower side of the communication (the
 microcontroller).
 
-Today's laptops/PCs don't support the serial communication protocol. So you can't directly connect
-your laptop to the microcontroller. But that's where the serial module comes in. This module will
+Today's computers don't support the serial communication protocol. So you can't directly connect
+your computer to the microcontroller. But that's where the serial module comes in. This module will
 sit between the two and expose a serial interface to the microcontroller and an USB interface to
-your laptop. The microcontroller will see your laptop as another serial device and your laptop
+your computer. The microcontroller will see your computer as another serial device and your computer
 will see the microcontroller as a virtual serial device.
 
 Now, let's get familiar with the serial module and the serial communication tools that your OS

--- a/src/10-serial-communication/README.md
+++ b/src/10-serial-communication/README.md
@@ -47,7 +47,7 @@ will see the microcontroller as a virtual serial device.
 Now, let's get familiar with the serial module and the serial communication tools that your OS
 offers. Pick a route:
 
-- [*nix](nix-tooling.md)
+- [\*nix](nix-tooling.md)
 - [Windows](windows-tooling.md)
 
 [ASC]: https://en.wikipedia.org/wiki/Asynchronous_serial_communication

--- a/src/10-serial-communication/loopbacks.md
+++ b/src/10-serial-communication/loopbacks.md
@@ -46,4 +46,4 @@ console.
 ---
 
 Now that you are familiar with sending and receiving data over serial port using minicom/PuTTY,
-let's make your microcontroller and your laptop talk!
+let's make your microcontroller and your computer talk!

--- a/src/10-serial-communication/nix-tooling.md
+++ b/src/10-serial-communication/nix-tooling.md
@@ -1,4 +1,4 @@
-# *nix tooling
+# \*nix tooling
 
 ## Newer revisions of the discovery board
 
@@ -33,7 +33,7 @@ $ dmesg | grep -i tty
 [  +0.000155] usb 3-2: FTDI USB Serial Device converter now attached to ttyUSB0
 ```
 
-But what's this `ttyUSB0` thing? It's a file of course! Everything is a file in *nix:
+But what's this `ttyUSB0` thing? It's a file of course! Everything is a file in \*nix:
 
 ``` console
 $ ls -l /dev/ttyUSB0

--- a/src/10-serial-communication/nix-tooling.md
+++ b/src/10-serial-communication/nix-tooling.md
@@ -2,7 +2,7 @@
 
 ## Newer revisions of the discovery board
 
-With newer revisions, if you connect the discovery board to your laptop / PC you
+With newer revisions, if you connect the discovery board to your computer you
 should see a new TTY device appear in `/dev`.
 
 ``` console
@@ -21,7 +21,7 @@ revisions. If you do have a newer revision skip the next section and move to the
 
 ## Older revisions of the discovery board / external serial module
 
-Connect the serial module to your laptop and let's find out what name the OS assigned to it.
+Connect the serial module to your computer and let's find out what name the OS assigned to it.
 
 > **NOTE** On macs, the USB device will named like this: `/dev/cu.usbserial-*`. You won't
 > find it using `dmesg`, instead use `ls -l /dev | grep cu.usb` and adjust the following 

--- a/src/10-serial-communication/windows-tooling.md
+++ b/src/10-serial-communication/windows-tooling.md
@@ -9,7 +9,7 @@ the terminal:
 $ mode
 ```
 
-It will print a list of devices that are connected to your laptop. The ones that start with `COM` in
+It will print a list of devices that are connected to your computer. The ones that start with `COM` in
 their names are serial devices. This is the kind of device we'll be working with. Take note of all
 the `COM` *ports* `mode` outputs *before* plugging the serial module.
 

--- a/src/11-usart/README.md
+++ b/src/11-usart/README.md
@@ -5,7 +5,7 @@ Synchronous/Asynchronous Receiver/Transmitter. This peripheral can be configured
 several communication protocols like the serial communication protocol.
 
 Throughout this chapter, we'll use serial communication to exchange information between the
-microcontroller and your laptop. But before we do that we have to wire up everything.
+microcontroller and your computer. But before we do that we have to wire up everything.
 
 I mentioned before that this protocol involves two data lines: TX and RX. TX stands for transmitter
 and RX stands for receiver. Transmitter and receiver are relative terms though; which line is the

--- a/src/11-usart/buffer-overrun.md
+++ b/src/11-usart/buffer-overrun.md
@@ -23,7 +23,7 @@ fn main() -> ! {
 }
 ```
 
-You probably received something like this on your laptop when you executed the program compiled in
+You probably received something like this on your computer when you executed the program compiled in
 debug mode.
 
 ``` console

--- a/src/11-usart/echo-server.md
+++ b/src/11-usart/echo-server.md
@@ -2,6 +2,6 @@
 
 Let's merge transmission and reception into a single program and write an echo server. An echo
 server sends back to the client the same text it sent. For this application, the microcontroller
-will be the server and you and your laptop will be the client.
+will be the server and you and your computer will be the client.
 
 This should be straightforward to implement. (hint: do it byte by byte)

--- a/src/11-usart/receive-a-single-byte.md
+++ b/src/11-usart/receive-a-single-byte.md
@@ -1,7 +1,7 @@
 # Receive a single byte
 
-So far we have sending data from the micro to your laptop. It's time to try the opposite: receiving
-data from your laptop.
+So far we have sending data from the micro to your computer. It's time to try the opposite: receiving
+data from your computer.
 
 There's a `RDR` register that will be filled with the data that comes from the RX line. If we read
 that register, we'll retrieve the data that the other side of the channel sent. The question is: How

--- a/src/11-usart/receive-a-single-byte.md
+++ b/src/11-usart/receive-a-single-byte.md
@@ -1,6 +1,6 @@
 # Receive a single byte
 
-So far we have sending data from the micro to your computer. It's time to try the opposite: receiving
+So far we have sending data from the microcontroller to your computer. It's time to try the opposite: receiving
 data from your computer.
 
 There's a `RDR` register that will be filled with the data that comes from the RX line. If we read

--- a/src/11-usart/send-a-single-byte.md
+++ b/src/11-usart/send-a-single-byte.md
@@ -1,6 +1,6 @@
 # Send a single byte
 
-Our first task will be to send a single byte from the microcontroller to the laptop over the serial
+Our first task will be to send a single byte from the microcontroller to the computer over the serial
 connection.
 
 This time, I'm going to provide you with an already initialized USART peripheral. You'll only have
@@ -16,5 +16,5 @@ minicom/PuTTY open.
 This program writes to the `TDR` register. This causes the `USART` peripheral to send one byte of
 information through the serial interface.
 
-On the receiving end, your laptop, you should see show the character `X` appear on minicom/PuTTY's
+On the receiving end, your computer, you should see show the character `X` appear on minicom/PuTTY's
 terminal.

--- a/src/11-usart/send-a-string.md
+++ b/src/11-usart/send-a-string.md
@@ -1,8 +1,8 @@
 # Send a string
 
-The next task will be to send a whole string from the micro to your computer.
+The next task will be to send a whole string from the microcontroller to your computer.
 
-I want you to send the string `"The quick brown fox jumps over the lazy dog."` from the micro to
+I want you to send the string `"The quick brown fox jumps over the lazy dog."` from the microcontroller to
 your computer.
 
 It's your turn to write the program.

--- a/src/11-usart/send-a-string.md
+++ b/src/11-usart/send-a-string.md
@@ -1,9 +1,9 @@
 # Send a string
 
-The next task will be to send a whole string from the micro to your laptop.
+The next task will be to send a whole string from the micro to your computer.
 
 I want you to send the string `"The quick brown fox jumps over the lazy dog."` from the micro to
-your laptop.
+your computer.
 
 It's your turn to write the program.
 

--- a/src/12-bluetooth-setup/README.md
+++ b/src/12-bluetooth-setup/README.md
@@ -27,7 +27,7 @@ The recommend steps to wire this up are:
 Two LEDs, a blue one and a red one, on the Bluetooth module should start blinking right after you
 power on the F3 board.
 
-Next thing to do is pair your laptop and the Bluetooth module. AFAIK, Windows and mac users can
+Next thing to do is pair your computer and the Bluetooth module. AFAIK, Windows and mac users can
 simply use their OS default Bluetooth manager to do the pairing. The Bluetooth module default pin
 is 1234.
 

--- a/src/12-bluetooth-setup/at-commands.md
+++ b/src/12-bluetooth-setup/at-commands.md
@@ -10,15 +10,15 @@ The Bluetooth module supports an AT mode that allows you to examine and change i
 
 Recommended steps to enter AT mode:
 
-- Disconnect the F3 and FTDI from your laptop.
+- Disconnect the F3 and FTDI from your computer.
 - Connect F3's GND pin to the Bluetooth's GND pin using a Female/Female (F/F) wire
   (preferably, a black one).
 - Connect F3's 5V pin to the Bluetooth's VCC pin using a F/F wire (preferably, a
   red one).
 - Connect the FTDI RXI pin to the Bluetooth's TXD pin using a Female/Male (F/M) wire.
 - Connect the FTDI TXO pin to the Bluetooth's RXD pin using a Female/Male (F/M) wire.
-- Now connect the FTDI to your laptop via USB cable.
-- Next connect the F3 to your laptop via USB cable while simultaneously pressing and holding the button on the Bluetooth module (kinda tricky).
+- Now connect the FTDI to your computer via USB cable.
+- Next connect the F3 to your computer via USB cable while simultaneously pressing and holding the button on the Bluetooth module (kinda tricky).
 - Now, release the button and the Bluetooth module will enter AT mode. You can confirm this by observing that the red LED on the Bluetooth module is blinking in a slow pattern (approx 1-2 seconds on/off).
 
 The AT mode always operates at a baud rate of 38400, so configure your terminal program for that baud rate and connect to the FTDI device.

--- a/src/12-bluetooth-setup/linux.md
+++ b/src/12-bluetooth-setup/linux.md
@@ -1,13 +1,13 @@
 # Linux
 
-If you have a graphical Bluetooth manager, you can use that to pair your laptop to the Bluetooth
+If you have a graphical Bluetooth manager, you can use that to pair your computer to the Bluetooth
 module and skip most of these steps. You'll probably still have to [this step] though.
 
 [this step]: #rfcomm-device
 
 ## Power up
 
-First, your laptop's Bluetooth transceiver may be OFF. Check its status with `hciconfig` and turn it
+First, your computer's Bluetooth transceiver may be OFF. Check its status with `hciconfig` and turn it
 ON if necessary:
 
 ``` console

--- a/src/12-bluetooth-setup/loopback.md
+++ b/src/12-bluetooth-setup/loopback.md
@@ -1,6 +1,6 @@
 # Loopback, again
 
-After pairing your laptop to the Bluetooth module, your OS should have created a device file / COM
+After pairing your computer to the Bluetooth module, your OS should have created a device file / COM
 port for you. On Linux, it should be `/dev/rfcomm*`; on mac, it should be `/dev/cu.*`; and on
 Windows, it should be a new COM port.
 

--- a/src/13-serial-over-bluetooth/README.md
+++ b/src/13-serial-over-bluetooth/README.md
@@ -10,13 +10,13 @@ microcontroller:
 Recommended steps to wire this up:
 
 - Close OpenOCD and `itmdump`.
-- Disconnect the F3 from your laptop.
+- Disconnect the F3 from your computer.
 - Connect F3's GND pin to the module's GND pin using a female to female (F/F) wire (preferably, a
   black one).
 - Connect F3's 5V pin to the module's VCC pin using a F/F wire (preferably, a red one).
 - Connect the PA9 (TX) pin on the back of the F3 to the Bluetooth's RXD pin using a F/F wire.
 - Connect the PA10 (RX) pin on the back of the F3 to the Bluetooth's TXD pin using a F/F wire.
-- Now connect the F3 and your laptop using an USB cable.
+- Now connect the F3 and your computer using an USB cable.
 - Re-launch OpenOCD and `itmdump`.
 
 And that's it! You should be able to run all the programs you wrote in [section 11] without

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -34,7 +34,7 @@
     - [Busy waiting](09-clocks-and-timers/busy-waiting.md)
     - [Putting it all together](09-clocks-and-timers/putting-it-all-together.md)
 - [Serial communication](10-serial-communication/README.md)
-    - [*nix tooling](10-serial-communication/nix-tooling.md)
+    - [\*nix tooling](10-serial-communication/nix-tooling.md)
     - [Windows tooling](10-serial-communication/windows-tooling.md)
     - [Loopbacks](10-serial-communication/loopbacks.md)
 - [USART](11-usart/README.md)


### PR DESCRIPTION
- Change `laptop/PC` into more general `computer`
- Change the short `micro` into `microcontroller`
- Properly escape `*` character in Markdown files
