### PR TITLE
Minor typo in type-safe-manipulation.md

### DIFF
--- a/src/07-registers/type-safe-manipulation.md
+++ b/src/07-registers/type-safe-manipulation.md
@@ -2,7 +2,7 @@
 
 The last register we were working with, `ODR`, had this in its documentation:
 
-> Bits 16:31 Reserved, must be kept at reset value
+> Bits 31:16 Reserved, must be kept at reset value
 
 We are not supposed to write to those bits of the register or Bad Stuff May Happen.
 


### PR DESCRIPTION
The STM32f3 reference manual contains the following: 

> Bits 31:16 Reserved, must be kept at reset value.

on page 239, section 11.4.6