### PR TITLE
Fix clock speed typo

### DIFF
--- a/src/09-clocks-and-timers/for-loop-delays.md
+++ b/src/09-clocks-and-timers/for-loop-delays.md
@@ -18,7 +18,7 @@ In this section, you'll have to:
 - Fix the `delay` function to generate delays proportional to its input `ms`.
 - Tweak the `delay` function to make the LED roulette spin at a rate of approximately 5 cycles in 4
   seconds (800 milliseconds period).
-- The processor inside the microcontroller is clocked at 8 MHz and executes most instructions in one
+- The processor inside the microcontroller is clocked at 80 MHz and executes most instructions in one
   "tick", a cycle of its clock. How many (`for`) loops do  you *think* the `delay` function must do
   to generate a delay of 1 second?
 - How many `for` loops does `delay(1000)` actually do?


### PR DESCRIPTION
I think this was meant to say `80MHz` (Rounded up from `72MHZ` speed of the STM32F303VC?).