### PR TITLE
Change clock speed to 72MHz

### DIFF
--- a/src/09-clocks-and-timers/for-loop-delays.md
+++ b/src/09-clocks-and-timers/for-loop-delays.md
@@ -18,7 +18,7 @@ In this section, you'll have to:
 - Fix the `delay` function to generate delays proportional to its input `ms`.
 - Tweak the `delay` function to make the LED roulette spin at a rate of approximately 5 cycles in 4
   seconds (800 milliseconds period).
-- The processor inside the microcontroller is clocked at 80 MHz and executes most instructions in one
+- The processor inside the microcontroller is clocked at 72 MHz and executes most instructions in one
   "tick", a cycle of its clock. How many (`for`) loops do  you *think* the `delay` function must do
   to generate a delay of 1 second?
 - How many `for` loops does `delay(1000)` actually do?


### PR DESCRIPTION
Original PR to fix typo was  #247, which was merged but incorrect. PR #248 was closed after determining the correct clock speed is `72MHz`, not 80 or 8.