### PR TITLE
Using the latest version (0.3.0) of cargo-binutils

### DIFF
--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -90,7 +90,7 @@ itmdump 0.3.1
 ``` console
 $ rustup component add llvm-tools-preview
 
-$ cargo install cargo-binutils --vers 0.1.4
+$ cargo install cargo-binutils --vers 0.3.0
 
 $ cargo size -- -version
 LLVM (http://llvm.org/):


### PR DESCRIPTION
I have an error when using version the old one (0.1.4) similar to https://github.com/rust-embedded/discovery/issues/184, when I'm upgrade to the latest one (0.3.0) it's resolved. On Windows 10 HS v2004.