### PR TITLE
Added Note on loading files from /target

### DIFF
--- a/src/05-led-roulette/flash-it.md
+++ b/src/05-led-roulette/flash-it.md
@@ -81,6 +81,8 @@ available.
 
 Leave that `openocd` process running, and open a new terminal. Make sure that you are inside the project's `src/05-led-roulette/` directory.
 
+**NOTE** if your target/ folder was created underneath the main project, you will have to have a terminal open underneath the main folder.
+
 I mentioned that OpenOCD provides a GDB server so let's connect to that right now:
 
 ``` console


### PR DESCRIPTION
Using Windows the relative path from the cmd prompt was not working:
------------------------------------------------------------------------------------------------------
C:\Program Files (x86)\GNU Arm Embedded Toolchain\9 2020-q2-update\bin\arm-none-eabi-gdb.exe: warning: Couldn't determine a path for the index cache directory.     
target/thumbv7em-none-eabihf/debug/led-roulette: No such file or directory.
(gdb) target remote :3333    
Remote debugging using :3333
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x08000c78 in ?? ()
(gdb) quit
A debugging session is active.

        Inferior 1 [Remote target] will be detached.

Quit anyway? (y or n) n
Not confirmed.
(gdb) quit
A debugging session is active.

        Inferior 1 [Remote target] will be detached.

Quit anyway? (y or n) y
Detaching from program: , Remote target
Ending remote debugging.
[Inferior 1 (Remote target) detached]

------------------------------------------------------------------------------------------------------

After going up a couple directories I was able to have it read the target files.

------------------------------------------------------------------------------------------------------
C:\Users\mike2\Documents\proging\Rust\embedded\discovery\src\05-led-roulette>cd ../..

C:\Users\mike2\Documents\proging\Rust\embedded\discovery>arm-none-eabi-gdb.exe  -q target/thumbv7em-none-eabihf/debug/led-roulette
C:\Program Files (x86)\GNU Arm Embedded Toolchain\9 2020-q2-update\bin\arm-none-eabi-gdb.exe: warning: Couldn't determine a path for the index cache directory.
Reading symbols from target/thumbv7em-none-eabihf/debug/led-roulette...
------------------------------------------------------------------------------------------------------