### PR TITLE
appendix: add hint about ST-LINK config version

### DIFF
--- a/src/appendix/1-general-troubleshooting/README.md
+++ b/src/appendix/1-general-troubleshooting/README.md
@@ -17,17 +17,29 @@ in procedure 'init'
 in procedure 'ocd_bouncer'
 ```
 
-#### Cause + Fix
+#### Cause
 
-- All: The device is not (properly) connected. Check the USB connection using
-  `lsusb` or the Device Manager.
-- Linux: You may not have enough permission to open the device. Try again with
-  `sudo`. If that works, you can use [these instructions] to make OpenOCD work
-  without root privilege.
-- Windows: You are probably missing the ST-LINK USB driver. Installation
-  instructions [here].
+The device is not (properly) connected or not the correct ST-LINK interface
+configuration is used.
+
+#### Fix
+
+Linux:
+
+- Check the USB connection using `lsusb`.
+- You may not have enough permission to open the device. Try again with `sudo`.
+  If that works, you can use [these instructions] to make OpenOCD work without
+  root privilege.
+- You might be using the wrong interface configuration for your ST-LINK.
+  Try `interface/stlink-v2.cfg` instead of `interface/stlink-v2-1.cfg`.
 
 [these instructions]: ../../03-setup/linux.md#udev-rules
+
+Windows:
+
+- You are probably missing the ST-LINK USB driver. Installation instructions
+  [here].
+
 [here]: ../../03-setup/windows.md#st-link-usb-driver
 
 ### can't connect to OpenOCD - "Polling again in X00ms"


### PR DESCRIPTION
My F3 seemed to come with the stlink-v2 and not the stlink-v2-1 config interface which caused the same "Error: open failed" output.

I suggest to hint to try the older version in that case.

I've also separated Cause and Fix headings because I didn't know how to phrase it otherwise.

Related to https://github.com/rust-embedded/book/issues/263.