### PR TITLE
06-hello-world: change note about solder bridge

### DIFF
--- a/src/06-hello-world/README.md
+++ b/src/06-hello-world/README.md
@@ -1,8 +1,8 @@
 # Hello, world!
 
-> **HEADS UP** Several readers have reported that the "solder bridge" SB10 (see back of the board)
-> on the STM32F3DISCOVERY, which is required to use the ITM and the `iprint!` macros shown below, is
-> **not** soldered even though the [User Manual][] (page 21) says that it **should be**.
+> **HEADS UP** The "solder bridge" SB10 (see back of the board) on the STM32F3DISCOVERY, which is
+> required to use the ITM and the `iprint!` macros shown below, is **not** soldered by default
+> (see page 21 of the [User Manual][]).
 
 > **TL;DR** You have two options to fix this: Either **solder** the solder bridge SB10 or connect a
 > female to female jumper wire between SWO and PB3 as shown in the picture below.


### PR DESCRIPTION
I got slightly confused by the note saying that the datasheet was wrong
about the solder bridge because from how I read it, it says:

![Screenshot_2020-10-31 Discovery kit with STM32F303VC MCU - User manual - dm00063382-discovery-kit-with-stm32f303vc-mcu-stmi](https://user-images.githubusercontent.com/1419688/97773722-75a5cb00-1b52-11eb-887d-4e453cfbd145.png)

I wonder if this might have been fixed in the datasheet in the meantime?