### PR TITLE
07-registers: Fix cargo objdump example

### DIFF
--- a/src/07-registers/type-safe-manipulation.md
+++ b/src/07-registers/type-safe-manipulation.md
@@ -176,7 +176,7 @@ did!
 [LTO]: https://en.wikipedia.org/wiki/Interprocedural_optimization
 
 ``` console
-$ cargo objdump --bin registers --release -- -d -no-show-raw-insn -print-imm-hex
+$ cargo objdump --bin registers --release -- -d --no-show-raw-insn --print-imm-hex
 registers:      file format ELF32-arm-little
 
 Disassembly of section .text:


### PR DESCRIPTION
The last code block of the Type Safe Manipulation section contains
invalid flags because they are missing a dash. Thankfully cargo is
intelligent enough to provide correct suggestions.

Suggestion from cargo:

```console
llvm-objdump: Unknown command line argument '-no-show-raw-insn'.  Try: '/home/itme/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objdump --help'
llvm-objdump: Did you mean '--no-show-raw-insn'?
llvm-objdump: Unknown command line argument '-print-imm-hex'.  Try: '/home/itme/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objdump --help'
llvm-objdump: Did you mean '--print-imm-hex'?
```