### PR TITLE
Change references to UserHardFault to HardFault in openocd.gdb

### DIFF
--- a/src/08-leds-again/openocd.gdb
+++ b/src/08-leds-again/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue

--- a/src/09-clocks-and-timers/openocd.gdb
+++ b/src/09-clocks-and-timers/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue

--- a/src/11-usart/openocd.gdb
+++ b/src/11-usart/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue

--- a/src/14-i2c/openocd.gdb
+++ b/src/14-i2c/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue

--- a/src/15-led-compass/openocd.gdb
+++ b/src/15-led-compass/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue

--- a/src/16-punch-o-meter/openocd.gdb
+++ b/src/16-punch-o-meter/openocd.gdb
@@ -5,6 +5,6 @@ monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
 break DefaultHandler
-break UserHardFault
+break HardFault
 break main
 continue


### PR DESCRIPTION
UserHardFault was renamed to HardFault in Feb. 2019:
 https://github.com/rust-embedded/cortex-m-rt/commit/790e42477ca21d6d0a07270049c3747c7c316f4b

Also, 07-registers was already changed, also in Feb. 2019:
 https://github.com/winksaville/rust-embedded-discovery/commit/1b0979183f348c13c7adb04c2ff10e8956f7e496

I propose this PR to fix the other references within the discovery book.