### PR TITLE
book.toml: add link to GitHub repo

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,4 @@ language = "en"
 
 [output.html]
 additional-css = ["custom.css"]
+git-repository-url = "https://github.com/rust-embedded/discovery/"


### PR DESCRIPTION
This will show a GitHub icon in the website that links to the repo