### PR TITLE
Fix specifying options in (mis)Optimization

### DIFF
--- a/src/07-registers/optimization.md
+++ b/src/07-registers/optimization.md
@@ -61,8 +61,8 @@ register, but the *release* (optimized) program only has one.
 We can check that using `objdump`:
 
 ``` console
-$ # same as cargo objdump -- -d -no-show-raw-insn -print-imm-hex -source target/thumbv7em-none-eabihf/debug/registers
-$ cargo objdump --bin registers -- -d -no-show-raw-insn -print-imm-hex -source
+$ # same as cargo objdump -- -d --no-show-raw-insn --print-imm-hex --source target/thumbv7em-none-eabihf/debug/registers
+$ cargo objdump --bin registers -- -d --no-show-raw-insn --print-imm-hex --source
 registers:      file format ELF32-arm-little
 
 Disassembly of section .text:
@@ -188,7 +188,7 @@ fn main() -> ! {
 If we look at the disassembly of this new program compiled in release mode:
 
 ``` console
-$ cargo objdump --bin registers --release -- -d -no-show-raw-insn -print-imm-hex -source
+$ cargo objdump --bin registers --release -- -d --no-show-raw-insn --print-imm-hex --source
 registers:      file format ELF32-arm-little
 
 Disassembly of section .text:

--- a/src/09-clocks-and-timers/nop.md
+++ b/src/09-clocks-and-timers/nop.md
@@ -25,7 +25,7 @@ fn delay(_tim6: &tim6::RegisterBlock, ms: u16) {
 And this time `delay` won't be compiled away by LLVM when you compile your program in release mode:
 
 ``` console
-$ cargo objdump --bin clocks-and-timers --release -- -d -no-show-raw-insn
+$ cargo objdump --bin clocks-and-timers --release -- -d --no-show-raw-insn
 clocks-and-timers:      file format ELF32-arm-little
 
 Disassembly of section .text:


### PR DESCRIPTION
- The long argument name options specified to `objdump` require
  two dashes '--'.

Fixes https://github.com/rust-embedded/discovery/issues/284 .