### PR TITLE
Fix installing dateutil since it is now a dependency of the GHP import script

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -16,6 +16,7 @@ main() {
 
     rustup target add thumbv7em-none-eabihf
 
+    pip install python-dateutil --user
     pip install linkchecker --user
 }
 


### PR DESCRIPTION
This would at least make our publication step work again even though still on Travis CI.
See #289 