### PR TITLE
New-06-hello-world

### DIFF
--- a/src/06-hello-world/.cargo/config
+++ b/src/06-hello-world/.cargo/config
@@ -3,3 +3,6 @@ runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]
+
+[build]
+target = "thumbv7em-none-eabihf"

--- a/src/06-hello-world/Cargo.toml
+++ b/src/06-hello-world/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = [
+    "Jorge Aparicio <jorge@japaric.io>",
+    "Wink Saville <wink@saville.com",
+]
 edition = "2018"
 name = "hello-world"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 aux6 = { path = "auxiliary" }

--- a/src/06-hello-world/README.md
+++ b/src/06-hello-world/README.md
@@ -70,73 +70,126 @@ $ itmdump -F -f itm.txt
 
 This command will block as `itmdump` is now watching the `itm.txt` file. Leave this terminal open.
 
-Make sure that F3 is connected to your computer. Open another terminal from `/tmp` directory (on Windows `%TEMP%`) to launch OpenOCD similar as described in chapter [First OpenOCD connection].
-
+Make sure that the STM32F3DISCOVERY board is connected to your computer. Open another terminal
+from `/tmp` directory (on Windows `%TEMP%`) to launch OpenOCD similar as described in chapter
 [First OpenOCD connection]: ../03-setup/verify.html#first-openocd-connection
 
 Alright. Now, let's build the starter code and flash it into the microcontroller.
 
-To avoid passing the `--target thumbv7em-none-eabihf` flag to every Cargo invocation we can set a
-default target in .cargo/config:
+To avoid passing the `--target thumbv7em-none-eabihf` flag to every Cargo invocation we
+have added `[build]` with a default target, `target = "thumbv7em-none-eabihf"`, to .cargo/config.
+Now if `--target` is not specified `cargo` will assume that the target is `thumbv7em-none-eabihf`.
 
-``` diff
- [target.thumbv7em-none-eabihf]
- runner = "arm-none-eabi-gdb -q -x openocd.gdb"
- rustflags = [
-   "-C", "link-arg=-Tlink.x",
- ]
+```
+[target.thumbv7em-none-eabihf]
+runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
 
-+[build]
-+target = "thumbv7em-none-eabihf"
+[build]
+target = "thumbv7em-none-eabihf"
 ```
 
-Now if `--target` is not specified Cargo will assume that the target is `thumbv7em-none-eabihf`.
+In addition, our `opendocd.gdb` has some additional lines. Compared to the previous
+section `set`'s and initialize `monitor`ing so `iprint!` and `iprintln!`
+macros work and output is visible on a console. Below the contents with comments:
+
+``` console
+$ cat openocd.gdb
+# Connect to gdb remote server
+target remote :3333
+
+# Load will flash the code
+load
+
+# Eanble demangling asm names on disassembly
+set print asm-demangle on
+
+# Enable pretty printing
+set print pretty on
+
+# Disable style sources as the default colors can be hard to read
+set style sources off
+
+# Have the tpiu send the data to a file itm.txt
+monitor tpiu config internal itm.txt uart off 8000000
+
+# Turn on the itm port
+monitor itm port 0 on
+
+# Set a breakpoint at main
+break main
+
+# Continue running and we'll hit the main breakpoint
+continue
+```
+
+We will now run the application and single step through it. Since we've added
+the `monitor` commands in `openocd.gdb` OpenOCD will redirect the ITM output to
+itm.txt and `itmdump` will write it to its terminal window.
 
 ``` console
 $ cargo run
-Reading symbols from target/thumbv7em-none-eabihf/debug/hello-world...done.
-(..)
-Loading section .vector_table, size 0x400 lma 0x8000000
-Loading section .text, size 0x27c4 lma 0x8000400
-Loading section .rodata, size 0x744 lma 0x8002be0
-Start address 0x8002980, load size 13064
-Transfer rate: 18 KB/sec, 4354 bytes/write.
-Breakpoint 1 at 0x8000402: file src/06-hello-world/src/main.rs, line 10.
+    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
+     Running `arm-none-eabi-gdb -q -x openocd.gdb ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/hello-world`
+Reading symbols from ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/hello-world...
+0x00000000 in ?? ()
+Loading section .vector_table, size 0x194 lma 0x8000000
+Loading section .text, size 0x28d8 lma 0x8000194
+Loading section .rodata, size 0x6b8 lma 0x8002a6c
+Start address 0x08000194, load size 12580
+Transfer rate: 18 KB/sec, 4193 bytes/write.
+Breakpoint 1 at 0x80001f0: file src/06-hello-world/src/main.rs, line 8.
 Note: automatically using hardware breakpoints for read-only addresses.
 
-Breakpoint 1, main () at src/06-hello-world/src/main.rs:10
-10          let mut itm = aux6::init();
+Breakpoint 1, hello_world::__cortex_m_rt_main_trampoline () at src/06-hello-world/src/main.rs:8
+8       #[entry]
 ```
 
-Note that there's a `openocd.gdb` at the root of the Cargo project. It's pretty similar to the one we
-used in the previous section.
+We are now stopped at `#[entry]` and since, as before, it's a trampoline:
 
-Before we execute the `iprintln!` statement. We have to instruct OpenOCD to redirect the ITM output
-into the same file that `itmdump` is watching.
-
-```
-(gdb) # globally enable the ITM and redirect all output to itm.txt
-(gdb) monitor tpiu config internal itm.txt uart off 8000000
-
-(gdb) # enable the ITM port 0
-(gdb) monitor itm port 0 on
+``` console
+(gdb) disassemble /m
+Dump of assembler code for function main:
+8	#[entry]
+   0x080001ec <+0>:	push	{r7, lr}
+   0x080001ee <+2>:	mov	r7, sp
+=> 0x080001f0 <+4>:	bl	0x80001f6 <hello_world::__cortex_m_rt_main>
+   0x080001f4 <+8>:	udf	#254	; 0xfe
 ```
 
-All should be ready! Now execute the `iprintln!` statement.
+We need to initially `step` into the main function which will position us at line 10:
 
+``` text
+(gdb) step
+hello_world::__cortex_m_rt_main () at src/06-hello-world/src/main.rs:10
+10	    let mut itm = aux6::init();
 ```
+
+Now issue a `next` command which will exectue `aux6::init()` and
+stop at he next executable statement in `main.rs`, which
+positions us at line 12:
+
+``` text
 (gdb) next
-12          iprintln!(&mut itm.stim[0], "Hello, world!");
-
-(gdb) next
-14          loop {}
+12	    iprintln!(&mut itm.stim[0], "Hello, world!");
 ```
 
-You should see some output in the `itmdump` terminal:
+Then issue another `next` command which will execute
+line 12, executing the `iprintln` and stop at line 14:
+
+``` text
+(gdb) next
+14	    loop {}
+```
+
+Now since `iprintln` has been executed the output on the `itmdump`
+terminal window should be the `Hello, world!` string:
 
 ``` console
 $ itmdump -F -f itm.txt
-(..)
+(...)
 Hello, world!
 ```
 

--- a/src/06-hello-world/auxiliary/Cargo.toml
+++ b/src/06-hello-world/auxiliary/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = [
+    "Jorge Aparicio <jorge@japaric.io>",
+    "Wink Saville <wink@saville.com",
+]
 edition = "2018"
 name = "aux6"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
-cortex-m = "0.6.3"
-cortex-m-rt = "0.6.3"
-panic-itm = "0.4.0"
-f3 = "0.6.1"
+cortex-m = "0.6.4"
+cortex-m-rt = "0.6.13"
+stm32f3-discovery = "0.5.0"
+panic-halt = "0.2.0"
+panic-itm = "0.4.2"

--- a/src/06-hello-world/auxiliary/src/lib.rs
+++ b/src/06-hello-world/auxiliary/src/lib.rs
@@ -2,13 +2,15 @@
 
 #![no_std]
 
-#[allow(unused_extern_crates)] // NOTE(allow) bug rust-lang/rust#53964
-extern crate f3; // provides memory.x
-#[allow(unused_extern_crates)] // NOTE(allow) bug rust-lang/rust#53964
-extern crate panic_itm; // panic handler
+pub use panic_itm;
+
+pub use cortex_m_rt::entry;
+
+// Need stm32f3xx_hal::prelude::* otherwise
+//   'Error(corex-m-rt): The interrupt vectors are missing`
+pub use stm32f3_discovery::stm32f3xx_hal::prelude::*;
 
 pub use cortex_m::{asm::bkpt, iprint, iprintln, peripheral::ITM};
-pub use cortex_m_rt::entry;
 
 pub fn init() -> ITM {
     let p = cortex_m::Peripherals::take().unwrap();

--- a/src/06-hello-world/openocd.gdb
+++ b/src/06-hello-world/openocd.gdb
@@ -1,6 +1,26 @@
+# Connect to gdb remote server
 target remote :3333
-set print asm-demangle on
-set print pretty on
+
+# Load will flash the code
 load
+
+# Eanble demangling asm names on disassembly
+set print asm-demangle on
+
+# Enable pretty printing
+set print pretty on
+
+# Disable style sources as the default colors can be hard to read
+set style sources off
+
+# Have the tpiu send the data to a file tim.txt
+monitor tpiu config internal itm.txt uart off 8000000
+
+# Turn on the itm port
+monitor itm port 0 on
+
+# Set a breakpoint at main
 break main
+
+# Continue running and we'll hit the main breakpoint
 continue

--- a/src/06-hello-world/panic.md
+++ b/src/06-hello-world/panic.md
@@ -13,7 +13,7 @@ fn main() -> ! {
 
 Before running one other suggestion, I find it inconvenient to have to
 confirm when quitting gdb. Add the following file in your home
-directory ~/.gdbinit so that it quits immediately:
+directory `~/.gdbinit` so that it quits immediately:
 
 ``` console
 $ cat ~/.gdbinit

--- a/src/06-hello-world/panic.md
+++ b/src/06-hello-world/panic.md
@@ -11,32 +11,45 @@ fn main() -> ! {
 }
 ```
 
-Let's try this program. But before that let's update `openocd.gdb` to run that `monitor` stuff for
-us during GDB startup:
+Before running one other suggestion, I find it inconvenient to have to
+confirm when quitting gdb. Add the following file in your home
+directory ~/.gdbinit so that it quits immediately:
 
-``` diff
- target remote :3333
- set print asm-demangle on
- set print pretty on
- load
-+monitor tpiu config internal itm.txt uart off 8000000
-+monitor itm port 0 on
- break main
- continue
+``` console
+$ cat ~/.gdbinit
+define hook-quit
+  set confirm off
+end
 ```
 
-OK, now run it.
+OK, now use `cargo run` and it stops at `#[entry]`:
 
 ``` console
 $ cargo run
-(..)
-Breakpoint 1, main () at src/06-hello-world/src/main.rs:10
-10          panic!("Hello, world!");
+    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
+     Running `arm-none-eabi-gdb -q -x openocd.gdb ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/hello-world`
+Reading symbols from ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/hello-world...
+panic_itm::panic (info=0x20009fa0) at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.4.2/src/lib.rs:57
+57	        atomic::compiler_fence(Ordering::SeqCst);
+Loading section .vector_table, size 0x194 lma 0x8000000
+Loading section .text, size 0x2198 lma 0x8000194
+Loading section .rodata, size 0x5d8 lma 0x800232c
+Start address 0x08000194, load size 10500
+Transfer rate: 17 KB/sec, 3500 bytes/write.
+Breakpoint 1 at 0x80001f0: file src/06-hello-world/src/main.rs, line 8.
+Note: automatically using hardware breakpoints for read-only addresses.
 
-(gdb) next
+Breakpoint 1, hello_world::__cortex_m_rt_main_trampoline () at src/06-hello-world/src/main.rs:8
+8	#[entry]
 ```
 
-You'll see some new output in the `itmdump` terminal.
+We'll use short command names to save typing, enter `c` then the `Enter` or `Return` key:
+```
+(gdb) c
+Continuing.
+```
+
+If all is well you'll see some new output in the `itmdump` terminal.
 
 ``` console
 $ # itmdump terminal
@@ -44,45 +57,80 @@ $ # itmdump terminal
 panicked at 'Hello, world!', src/06-hello-world/src/main.rs:10:5
 ```
 
-<!-- FIXME backtraces appear to be broken? -->
-
-<!-- You won't get a `RUST_BACKTRACE` style backtrace in `itmdump`'s output, *but* -->
-<!-- you can get the equivalent inside GDB. You already know the command: -->
-
-<!-- ``` -->
-<!-- (gdb) backtrace -->
-<!-- #0  __bkpt () at asm/bkpt.s:3 -->
-<!-- #1  0x08000224 in cortex_m::asm::bkpt () -->
-<!--     at $REGISTRY/cortex-m-0.5.2/src/asm.rs:19 -->
-<!-- #2  rust_begin_unwind (info=0x10001f84) at src/06-hello-world/auxiliary/src/lib.rs:31 -->
-<!-- #3  0x08002548 in core::panicking::panic_fmt () at libcore/panicking.rs:92 -->
-<!-- #4  0x080024d8 in core::panicking::panic () at libcore/panicking.rs:53 -->
-<!-- #5  0x08000194 in hello_world::main () at src/06-hello-world/src/main.rs:14 -->
-<!-- ``` -->
-
-<!-- Ultimately, `panic!` is just another function call so you can see it leaves behind a trace of -->
-<!-- function calls. -->
-
-Another thing you can do is catch the panic *before* it does the logging by
-putting a breakpoint on the `rust_begin_unwind` symbol.
-
+Then type `Ctrl-c` which breaks out of a loop in the runtime:
+``` text
+^C
+Program received signal SIGINT, Interrupt.
+0x0800115c in panic_itm::panic (info=0x20009fa0) at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.4.2/src/lib.rs:57
+57	        atomic::compiler_fence(Ordering::SeqCst);
 ```
+
+Ultimately, `panic!` is just another function call so you can see it leaves behind
+a trace of function calls. This allows you to use `backtrace` or just `bt` and to see
+call stack that caused the panic:
+
+``` text
+(gdb) bt
+#0  panic_itm::panic (info=0x20009fa0) at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.4.2/src/lib.rs:47
+#1  0x080005c2 in core::panicking::panic_fmt () at library/core/src/panicking.rs:92
+#2  0x0800055a in core::panicking::panic () at library/core/src/panicking.rs:50
+#3  0x08000210 in hello_world::__cortex_m_rt_main () at src/06-hello-world/src/main.rs:10
+#4  0x080001f4 in hello_world::__cortex_m_rt_main_trampoline () at src/06-hello-world/src/main.rs:8
+```
+
+Another thing we can do is catch the panic *before* it does the logging.
+So we'll do several things; reset to the beginning, disable breakpoint 1,
+set a new breakpoint at `rust_begin_unwind`, list the break points and then continue:
+
+``` text
 (gdb) monitor reset halt
-(..)
-target halted due to debug-request, current mode: Thread
-xPSR: 0x01000000 pc: 0x080026ba msp: 0x10002000
+Unable to match requested speed 1000 kHz, using 950 kHz
+Unable to match requested speed 1000 kHz, using 950 kHz
+adapter speed: 950 kHz
+target halted due to debug-request, current mode: Thread 
+xPSR: 0x01000000 pc: 0x08000194 msp: 0x2000a000
 
-(gdb) break rust_begin_unwind
-Breakpoint 2 at 0x80011d2: file $REGISTRY/panic-itm-0.4.0/src/lib.rs, line 46.
+(gdb) disable 1
 
-(gdb) continue
+(gdb) break rust_begin_unwind 
+Breakpoint 2 at 0x80010f0: file ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.4.2/src/lib.rs, line 47.
+
+(gdb) info break
+Num     Type           Disp Enb Address    What
+1       breakpoint     keep n   0x080001f0 in hello_world::__cortex_m_rt_main_trampoline at src/06-hello-world/src/main.rs:8
+        breakpoint already hit 1 time
+2       breakpoint     keep y   0x080010f0 in panic_itm::panic 
+                                           at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.4.2/src/lib.rs:47
+
+(gdb) c
 Continuing.
 
-Breakpoint 2, rust_begin_unwind (info=0x10001fac) at $REGISTRY/panic-itm-0.4.0/src/lib.rs:46
-46          interrupt::disable();
+Breakpoint 2, panic_itm::panic (info=0x20009fa0) at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.4.2/src/lib.rs:47
+47          interrupt::disable();
 ```
 
 You'll notice that nothing got printed on the `itmdump` console this time. If
 you resume the program using `continue` then a new line will be printed.
 
 In a later section we'll look into other simpler communication protocols.
+
+Finally, enter the `q` command to quit and it quits immediately without asking for confirmation:
+
+``` text
+(gdb) q
+Detaching from program: ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/hello-world, Remote target
+Ending remote debugging.
+[Inferior 1 (Remote target) detached]
+```
+
+As an even shorter sequence you can type `Ctrl-d`, which eliminates
+one keystroke!
+
+> **NOTE** In this case the `(gdb)` prompt is overwritten with `quit)`
+
+``` text
+quit)
+Detaching from program: ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/hello-world, Remote target
+Ending remote debugging.
+[Inferior 1 (Remote target) detached]
+```


### PR DESCRIPTION
Converted lib.rs, Cargo.toml to use stm32f3_discovery.

.cargo/config:
 I also, found that I would forget to to use `--target` when
 building and running using cargo so set the default build target
 to thumbv7em-none-eabihf

openocd.cfg:
 Since the monitor lines are quite long and also easy to mistype or
 forget to do I enhanced the file with the new lines and commented
 on each of the lines.

README.md
 Update to reflect the above changes.