### PR TITLE
Update-03-setting-up-a-dev-env

### DIFF
--- a/src/03-setup/README.md
+++ b/src/03-setup/README.md
@@ -38,7 +38,7 @@ should work but we have listed the version we have tested.
 
 - Rust 1.31 or a newer toolchain.
 
-- [`itmdump`] v0.3.1 (`cargo install itm`)
+- [`itmdump`] >=0.3.1 (`cargo install itm`). Tested versions: 0.3.1.
 
 - OpenOCD >=0.8. Tested versions: v0.9.0 and v0.10.0
 
@@ -84,37 +84,70 @@ rustc 1.31.0 (abe02cefd 2018-12-04)
 
 ### `itmdump`
 
-``` console
-$ cargo install itm --vers 0.3.1
 
+``` console
+cargo install itm
+```
+
+Verify the version is >=0.3.1
+```
 $ itmdump -V
 itmdump 0.3.1
 ```
 
 ### `cargo-binutils`
 
+Install `llvm-tools-preview`
+
 ``` console
-$ rustup component add llvm-tools-preview
+rustup component add llvm-tools-preview
+```
 
-$ cargo install cargo-binutils
+Install `cargo-binutils`
+```
+cargo install cargo-binutils
+```
 
+#### Verify tools are installed
+
+Run the following commands at your terminal
+``` console
+cargo new test-size
+```
+```
+cd test-size
+```
+```
+cargo run
+```
+```
+cargo size -- -version
+```
+
+The results should be something like:
+```
+~
 $ cargo new test-size
      Created binary (application) `test-size` package
 
+~
 $ cd test-size
 
+~/test-size (main)
 $ cargo run
-    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-     Running `target\debug\test-size.exe`
+   Compiling test-size v0.1.0 (~/test-size)
+    Finished dev [unoptimized + debuginfo] target(s) in 0.26s
+     Running `target/debug/test-size`
 Hello, world!
 
+~/test-size (main)
 $ cargo size -- -version
-    Finished dev [unoptimized + debuginfo] target(s) in 0.50s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
 LLVM (http://llvm.org/):
-  LLVM version 11.0.0-rust-1.49.0-stable
+  LLVM version 11.0.0-rust-1.50.0-stable
   Optimized build.
-  Default target: x86_64-pc-windows-msvc
-  Host CPU: skylake
+  Default target: x86_64-unknown-linux-gnu
+  Host CPU: znver2
 ```
 
 ### OS specific instructions

--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -18,7 +18,7 @@ Here are the installation commands for a few Linux distributions.
 <!-- OpenOCD 0.10.0 -->
 
 ``` console
-$ sudo apt-get install \
+sudo apt-get install \
   gdb-multiarch \
   minicom \
   openocd
@@ -34,7 +34,7 @@ $ sudo apt-get install \
 <!-- OpenOCD 0.7.0 -->
 
 ``` console
-$ sudo apt-get install \
+sudo apt-get install \
   gdb-arm-none-eabi \
   minicom \
   openocd
@@ -46,7 +46,7 @@ $ sudo apt-get install \
 > Cortex-M programs
 
 ``` console
-$ sudo dnf install \
+sudo dnf install \
   arm-none-eabi-gdb \
   minicom \
   openocd
@@ -58,7 +58,7 @@ $ sudo dnf install \
 > Cortex-M programs
 
 ``` console
-$ sudo pacman -S \
+sudo pacman -S \
   arm-none-eabi-gdb \
   minicom \
   openocd
@@ -75,15 +75,17 @@ download the "Linux 64-bit" file and put its `bin` directory on your path.
 Here's one way to do it:
 
 ``` console
-$ mkdir -p ~/local && cd ~/local
-$ tar xjf /path/to/downloaded/file/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2.tbz
+mkdir -p ~/local && cd ~/local
+```
+``` console
+tar xjf /path/to/downloaded/file/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
 ```
 
 Then, use your editor of choice to append to your `PATH` in the appropriate
 shell init file (e.g. `~/.zshrc` or `~/.bashrc`):
 
 ```
-PATH=$PATH:$HOME/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+PATH=$PATH:$HOME/local/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux/bin
 ```
 
 ## Optional packages
@@ -91,7 +93,7 @@ PATH=$PATH:$HOME/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 ### Ubuntu / Debian
 
 ``` console
-$ sudo apt-get install \
+sudo apt-get install \
   bluez \
   rfkill
 ```
@@ -99,7 +101,7 @@ $ sudo apt-get install \
 ### Fedora
 
 ``` console
-$ sudo dnf install \
+sudo dnf install \
   bluez \
   rfkill
 ```
@@ -107,7 +109,7 @@ $ sudo dnf install \
 ### Arch Linux
 
 ``` console
-$ sudo pacman -S \
+sudo pacman -S \
   bluez \
   bluez-utils \
   rfkill
@@ -118,35 +120,49 @@ $ sudo pacman -S \
 These rules let you use USB devices like the F3 and the Serial module without root privilege, i.e.
 `sudo`.
 
-Create these two files in `/etc/udev/rules.d` with the contents shown below.
+Create `99-openocd.rules` in `/etc/udev/rules.d` using the `idVendor` and `idProduct`
+from the `lsusb` output.
 
+For example, connect the STM32F3DISCOVERY to your computer using a USB cable.
+Be sure to connect the cable to the "USB ST-LINK" port, the USB port in the
+center of the edge of the board.
+
+Execute `lsusb`:
 ``` console
-$ cat /etc/udev/rules.d/99-ftdi.rules
+lsusb | grep ST-LINK
 ```
+It should result in something like:
+```
+$ lsusb | grep ST-LINK
+Bus 003 Device 003: ID 0483:374b STMicroelectronics ST-LINK/V2.1
+```
+So the `idProduct` is `0483` and `idVendor` is `374b`.
 
+### Create `/etc/udev/rules.d/99-openocd.rules`:
+``` console
+sudo vi /etc/udev/rules.d/99-openocd.rules
+```
+With the contents:
+``` text
+# STM32F3DISCOVERY - ST-LINK/V2.1
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE:="0666"
+```
+#### For older devices with OPTIONAL USB <-> FT232 based Serial Module
+
+Create `/etc/udev/rules.d/99-ftdi.rules`:
+``` console
+sudo vi /etc/udev/rules.d/99-openocd.rules
+```
+With the contents:
 ``` text
 # FT232 - USB <-> Serial Converter
 ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE:="0666"
 ```
 
-If you have a different USB <-> Serial converter, get its vendor and product ids from `lsusb` output.
+### Reload the udev rules with:
 
 ``` console
-$ cat /etc/udev/rules.d/99-openocd.rules
-```
-
-``` text
-# STM32F3DISCOVERY rev A/B - ST-LINK/V2
-ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", MODE:="0666"
-
-# STM32F3DISCOVERY rev C+ - ST-LINK/V2-1
-ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE:="0666"
-```
-
-Then reload the udev rules with:
-
-``` console
-$ sudo udevadm control --reload-rules
+sudo udevadm control --reload-rules
 ```
 
 If you had any board plugged to your computer, unplug them and then plug them in again.

--- a/src/03-setup/macos.md
+++ b/src/03-setup/macos.md
@@ -4,13 +4,17 @@ All the tools can be install using [Homebrew]:
 
 [Homebrew]: http://brew.sh/
 
+Install ArmMbed
 ``` console
-$ # Arm GCC toolchain
-$ brew tap ArmMbed/homebrew-formulae
-$ brew install arm-none-eabi-gcc
-
-$ # Minicom and OpenOCD
-$ brew install minicom openocd
+brew tap ArmMbed/homebrew-formulae
+```
+Install the ARM GCC toolchain
+``` console
+brew install arm-none-eabi-gcc
+```
+Install minicom and OpenOCD
+``` console
+brew install minicom openocd
 ```
 
 That's all! Go to the [next section].

--- a/src/03-setup/windows.md
+++ b/src/03-setup/windows.md
@@ -6,9 +6,14 @@ ARM provides `.exe` installers for Windows. Grab one from [here][gcc], and follo
 Just before the installation process finishes tick/select the "Add path to environment variable"
 option. Then verify that the tools are in your `%PATH%`:
 
+Verify gcc is installed:
 ``` console
-$ arm-none-eabi-gcc -v
+arm-none-eabi-gcc -v
+```
+The results should be something like:
+```
 (..)
+$ arm-none-eabi-gcc -v
 gcc version 5.4.1 20160919 (release) (..)
 ```
 
@@ -24,8 +29,11 @@ before).
 
 [openocd]: https://github.com/xpack-dev-tools/openocd-xpack/releases
 
-Verify that OpenOCD is in yout `%PATH%` with:
-
+Verify OpenOCD is installed and in your `%PATH%` with:
+``` console
+openocd -v
+```
+The results should be something like:
 ``` console
 $ openocd -v
 Open On-Chip Debugger 0.10.0


### PR DESCRIPTION
Update `*.md` files so that copy-to-clipboard button in code blocks
works so that commands can be copied and pasted into terminal windows.

Some reorganization of the text for clarity.