### PR TITLE
Update 05 led-roulette

### DIFF
--- a/src/05-led-roulette/README.md
+++ b/src/05-led-roulette/README.md
@@ -44,6 +44,7 @@ point function must have signature `fn() -> !`; this type indicates that the fun
 If you are a careful observer, you'll also notice there is a `.cargo` directory in the Cargo project
 as well. This directory contains a Cargo configuration file (`.cargo/config`) that tweaks the
 linking process to tailor the memory layout of the program to the requirements of the target device.
-This modified linking process is a requirement of the `cortex-m-rt` crate.
+This modified linking process is a requirement of the `cortex-m-rt` crate. You'll also be making
+further tweaks to `.cargo/config` in future sections to make building and debugging easier.
 
 Alright, let's start by building this program.

--- a/src/05-led-roulette/auxiliary/Cargo.toml
+++ b/src/05-led-roulette/auxiliary/Cargo.toml
@@ -11,6 +11,6 @@ version = "0.2.0"
 [dependencies]
 cortex-m = "0.6.4"
 cortex-m-rt = "0.6.13"
-stm32f3-discovery = "0.5.0"
+stm32f3-discovery = "0.6.0"
 panic-halt = "0.2.0"
 panic-itm = "0.4.2"

--- a/src/05-led-roulette/build-it.md
+++ b/src/05-led-roulette/build-it.md
@@ -19,31 +19,74 @@ download pre-compiled version of the standard library (a reduced version of it a
 target. That's done using `rustup`:
 
 ``` console
-$ rustup target add thumbv7em-none-eabihf
+rustup target add thumbv7em-none-eabihf
 ```
 
 You only need to do the above step once; `rustup` will re-install a new standard library
 (`rust-std` component) whenever you update your toolchain.
 
-With the `rust-std` component in place you can now cross compile the program using Cargo:
+With the `rust-std` component in place you can now cross compile the program using Cargo.
 
+> Note: make sure you are in the `src/05-led-roulette` directory
+> and run `cargo build` command below to create the executable:
 ``` console
-$ # make sure you are in the `src/05-led-roulette` directory
-
+cargo build --target thumbv7em-none-eabihf
+```
+On your console you should see something like:
+``` console
 $ cargo build --target thumbv7em-none-eabihf
    Compiling typenum v1.12.0
    Compiling semver-parser v0.7.0
    Compiling version_check v0.9.2
-   Compiling cortex-m v0.6.4
+   Compiling nb v1.0.0
+   Compiling void v1.0.2
+   Compiling autocfg v1.0.1
+   Compiling cortex-m v0.7.1
+   Compiling proc-macro2 v1.0.24
+   Compiling vcell v0.1.3
+   Compiling unicode-xid v0.2.1
+   Compiling stable_deref_trait v1.2.0
+   Compiling syn v1.0.60
+   Compiling bitfield v0.13.2
+   Compiling cortex-m v0.6.7
    Compiling cortex-m-rt v0.6.13
-   Compiling stm32f3-discovery v0.5.0
-   ...
+   Compiling r0 v0.2.2
+   Compiling stm32-usbd v0.5.1
+   Compiling stm32f3 v0.12.1
+   Compiling usb-device v0.2.7
+   Compiling cfg-if v1.0.0
+   Compiling paste v1.0.4
+   Compiling stm32f3-discovery v0.6.0
+   Compiling panic-halt v0.2.0
+   Compiling embedded-dma v0.1.2
+   Compiling volatile-register v0.2.0
+   Compiling nb v0.1.3
+   Compiling embedded-hal v0.2.4
+   Compiling semver v0.9.0
+   Compiling generic-array v0.14.4
+   Compiling switch-hal v0.3.2
+   Compiling num-traits v0.2.14
+   Compiling num-integer v0.1.44
+   Compiling rustc_version v0.2.3
+   Compiling bare-metal v0.2.5
+   Compiling cast v0.2.3
+   Compiling quote v1.0.9
+   Compiling generic-array v0.13.2
+   Compiling generic-array v0.12.3
+   Compiling generic-array v0.11.1
    Compiling panic-itm v0.4.2
+   Compiling lsm303dlhc v0.2.0
+   Compiling as-slice v0.1.4
+   Compiling micromath v1.1.0
+   Compiling accelerometer v0.12.0
+   Compiling chrono v0.4.19
+   Compiling aligned v0.3.4
+   Compiling rtcc v0.2.0
    Compiling cortex-m-rt-macros v0.1.8
-   Compiling stm32f3xx-hal v0.5.0
-   Compiling aux5 v0.2.0 (file://$PWD/auxiliary)
-   Compiling led-roulette v0.2.0 (file://$PWD/)
-    Finished dev [unoptimized + debuginfo] target(s) in 19.45s
+   Compiling stm32f3xx-hal v0.6.1
+   Compiling aux5 v0.2.0 (~/embedded-discovery/src/05-led-roulette/auxiliary)
+   Compiling led-roulette v0.2.0 (~/embedded-discovery/src/05-led-roulette)
+    Finished dev [unoptimized + debuginfo] target(s) in 17.91s
 ```
 
 > **NOTE** Be sure to compile this crate *without* optimizations. The provided Cargo.toml file and build command above will ensure optimizations are off. 
@@ -51,9 +94,14 @@ $ cargo build --target thumbv7em-none-eabihf
 OK, now we have produced an executable. This executable won't blink any leds, it's just a simplified version that we will build upon later in the chapter. As a sanity check, let's verify that the produced executable is actually an ARM binary:
 
 ``` console
-$ # equivalent to `readelf -h target/thumbv7em-none-eabihf/debug/led-roulette`
-$ cargo readobj --target thumbv7em-none-eabihf --bin led-roulette -- -file-headers
-    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
+cargo readobj --target thumbv7em-none-eabihf --bin led-roulette -- --file-header
+```
+The `cargo readobj ..` above is equivalent to
+`readelf -h target/thumbv7em-none-eabihf/debug/led-roulette`
+and should produce something similar to:
+``` console
+$ cargo readobj --target thumbv7em-none-eabihf --bin led-roulette -- --file-header
+    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
 ELF Header:
   Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00
   Class:                             ELF32
@@ -66,7 +114,7 @@ ELF Header:
   Version:                           0x1
   Entry point address:               0x8000195
   Start of program headers:          52 (bytes into file)
-  Start of section headers:          797192 (bytes into file)
+  Start of section headers:          818328 (bytes into file)
   Flags:                             0x5000400
   Size of this header:               52 (bytes)
   Size of program headers:           32 (bytes)

--- a/src/05-led-roulette/debug-it.md
+++ b/src/05-led-roulette/debug-it.md
@@ -8,13 +8,32 @@ processor / CPU will execute first.
 
 The starter project I've provided to you has some extra code that runs *before* the `main` function.
 At this time, we are not interested in that "pre-main" part so let's skip right to the beginning of
-the `main` function. We'll do that using a breakpoint:
+the `main` function. We'll do that using a breakpoint. Issue `break main` at the `(gdb)` prompt:
 
+> **Note** for these gdb commands I generally won't provide a copyable code block
+> as these are short and it's faster just to type them yourself. In addition most
+> can be shortend. For instance `b` for `break` or `s` for `step`, see [gdb quick ref]
+> for more info or use Google to find your others. In addition, you can use tab completion
+> by typing the first few letters than one tab to complete or two tabs to
+> see all possible commands.
+>
+>> Finally, `help xxxx` where xxxx is the comand will provide short names and other info:
+>> ```
+>> (gdb) help s
+>> step, s
+>> Step program until it reaches a different source line.
+>> Usage: step [N]
+>> Argument N means step N times (or till program stops for another reason).
+>> ```
+
+[gdb quick ref]: https://users.ece.utexas.edu/~adnan/gdb-refcard.pdf
 ```
 (gdb) break main
 Breakpoint 1 at 0x80001f0: file src/05-led-roulette/src/main.rs, line 7.
 Note: automatically using hardware breakpoints for read-only addresses.
-
+```
+Next issue a `continue` command:
+```
 (gdb) continue
 Continuing.
 
@@ -57,9 +76,9 @@ led_roulette::__cortex_m_rt_main () at src/05-led-roulette/src/main.rs:10
 Next we'll issue a second `step` which executes line 10 and stops at
 line `11    _y = x;`, again line 11 is **not** executed.
 
-> **Note** we could have pressed enter at the second `<gdb> ` prompt and
-> it would have reissued the previous statement, `step`, but for clarity in this tutorial
-> we'll generally retype the command.
+> **Note** we could have pressed enter at the second `(gdb) ` prompt and
+> it would have reissued the previous statement, `step`, but for clarity
+> in this tutorial we'll generally retype the command.
 
 ```
 (gdb) step
@@ -71,16 +90,17 @@ along with its line number. As you'll see later in the TUI mode you'll not the s
 in the command area.
 
 We are now "on" the `_y = x` statement; that statement hasn't been executed yet. This means that `x`
-is initialized but `_y` is not. Let's inspect those stack/local variables using the `print` command:
+is initialized but `_y` is not. Let's inspect those stack/local variables using the `print`
+command, `p` for short:
 
 ```
 (gdb) print x
 $1 = 42
-(gdb) print &x
+(gdb) p &x
 $2 = (*mut i32) 0x20009fe0
-(gdb) print _y
+(gdb) p _y
 $3 = 536870912
-(gdb) print &_y
+(gdb) p &_y
 $4 = (*mut i32) 0x20009fe4
 ```
 
@@ -154,7 +174,7 @@ See the fat arrow `=>` on the left side? It shows the instruction the processor 
 
 Also, as mentioned above if you were to execute the `step` command GDB gets stuck because it
 is executing a branch instruction to itself and never gets past it. So you need to use
-`Ctrl+C` to regain control. An alternative is to use the `stepi` GDB command, which steps
+`Ctrl+C` to regain control. An alternative is to use the `stepi`(`si`) GDB command, which steps
 one asm instruction, and GDB will print the address **and** line number of the statement
 the processor will execute next and it won't get stuck.
 
@@ -162,7 +182,7 @@ the processor will execute next and it won't get stuck.
 (gdb) stepi
 0x08000194      14          loop {}
 
-(gdb) stepi
+(gdb) si
 0x08000194      14          loop {}
 ```
 
@@ -233,35 +253,40 @@ mode enter one of the following commands in the GDB shell:
 > **NOTE** Apologies to Windows users, the GDB shipped with the GNU ARM Embedded Toolchain
 > may not support this TUI mode `:-(`.
 
-Below is an example of setting up for a layout split by executing the follow commands:
+Below is an example of setting up for a `layout split` by executing the follow commands:
 
 ``` console
 $ cargo run --target thumbv7em-none-eabihf
-<gdb> target remote :3333
-<gdb> load
-<gdb> set print asm-demangle on
-<gdb> set style sources off
-<gdb> break main
-<gdb> continue
-<gdb> layout split
+(gdb) target remote :3333
+(gdb) load
+(gdb) set print asm-demangle on
+(gdb) set style sources off
+(gdb) break main
+(gdb) continue
 ```
 
-And below the result after `layout split` command is executed:
+Here is a command line with the above commands as `-ex` parameters to save you some typing:
+
+```
+cargo run --target thumbv7em-none-eabihf -- -q -ex 'target remote :3333' -ex 'load' -ex 'set print asm-demangle on' -ex 'set style sources off' -ex 'b main' -ex 'c' target/thumbv7em-none-eabihf/debug/led-roulette
+```
+
+And below is the result:
 
 ![GDB session layout split](../assets/gdb-layout-split-1.png "GDB TUI layout split 1")
 
-Now we'll scroll the top source window down so we see the entire file and execute `step`:
+Now we'll scroll the top source window down so we see the entire file and execute `layout split` and then `step`:
 
 ![GDB session layout split](../assets/gdb-layout-split-2.png "GDB TUI layout split 2")
 
 Then we'll execute a few `info locals` and `step`'s:
 
 ``` console
-<gdb> info locals
-<gdb> step
-<gdb> info locals
-<gdb> step
-<gdb> info locals
+(gdb) info locals
+(gdb) step
+(gdb) info locals
+(gdb) step
+(gdb) info locals
 ```
 
 ![GDB session layout split](../assets/gdb-layout-split-3.png "GDB TUI layout split 3")

--- a/src/05-led-roulette/flash-it.md
+++ b/src/05-led-roulette/flash-it.md
@@ -140,10 +140,80 @@ In both failing and successful cases you should see new output in the **OpenOCD 
 By default OpenOCD's GDB server listens on TCP port 3333 (localhost). This command is connecting to
 that port.
 
+## Update .cargo/config
+
+Now that you've successfully determined which debugger you need to use
+we need to change `.cargo/config` so that `cargo run` command can succeed.
+
+Get back to the terminal prompt and looking at `.cargo/config`:
+``` console
+$ cat .cargo/config
+[target.thumbv7em-none-eabihf]
+runner = "arm-none-eabi-gdb -q"
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+```
+Use your favorite editor to edit `.cargo/config` so that the
+runner line contains the name of that debugger:
+``` console
+nano .cargo/config
+```
+For example, if your debugger was `gdb-multiarch` then after
+editing you should have:
+``` console
+$ cat .cargo/config
+[target.thumbv7em-none-eabihf]
+runner = "gdb-mulitarch -q"
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+```
+And `git diff` should be:
+``` diff
+$ git diff .cargo/config
+diff --git a/src/05-led-roulette/.cargo/config b/src/05-led-roulette/.cargo/config
+index 01d25c8..c23dc80 100644
+--- a/src/05-led-roulette/.cargo/config
++++ b/src/05-led-roulette/.cargo/config
+@@ -1,5 +1,5 @@
+ [target.thumbv7em-none-eabihf]
+-runner = "arm-none-eabi-gdb -q"
++runner = "gdb-multiarch -q"
+ rustflags = [
+   "-C", "link-arg=-Tlink.x",
+ ]
+```
+
+Now that you have `.cargo/config` setup to let's test it and use `cargo run` to
+start the debug session:
+```
+~/embedded-discovery/src/05-led-roulette
+$ cargo run --target thumbv7em-none-eabihf
+    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
+     Running `arm-none-eabi-gdb -q ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette`
+Reading symbols from ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette...
+
+(gdb) target remote :3333
+Remote debugging using :3333
+0x00000000 in ?? ()
+
+(gdb)
+```
+
+Bravo, you'll be making additional changes to `.cargo/config` in future
+sections to make building and debugging easier.
+
+> **Note** the default `.cargo/config` in every chapter assumes
+> the debugger is `arm-none-eabi-gdb`. So the first thing you should
+> do when you start a new chapter is edit `.cargo/config`!
+
 ## Flash the device
 
-Almost there. To flash the device, we'll use the `load` command inside the GDB shell:
+Assuming you have gdb running, if not start it as suggested in the previous section.
 
+Now use the `load` command in `gdb` to actually flash the program into the device:
 ```
 (gdb) load
 Loading section .vector_table, size 0x194 lma 0x8000000

--- a/src/05-led-roulette/flash-it.md
+++ b/src/05-led-roulette/flash-it.md
@@ -11,19 +11,18 @@ Onto the actual flashing. First thing we need is to do is launch OpenOCD. We did
 previous section but this time we'll run the command inside a temporary directory (`/tmp` on \*nix;
 `%TEMP%` on Windows).
 
-Make sure the F3 is connected to your computer and run the following commands on a new terminal.
+Make sure the F3 is connected to your computer and run the following commands on a **new terminal**.
 
+## For *nix & MacOS:
 ``` console
-$ # *nix
-$ cd /tmp
+cd /tmp
+openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+```
 
-$ # Windows
-$ cd %TEMP%
-
-$ # Windows: remember that you need an extra `-s %PATH_TO_OPENOCD%\share\scripts`
-$ openocd \
-  -f interface/stlink-v2-1.cfg \
-  -f target/stm32f3x.cfg
+## For Windows **Note**: substitute `C:` for the actual OpenOCD path:
+```
+cd %TEMP%
+openocd -s C:\share\scripts -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
 ```
 
 > **NOTE** Older revisions of the board need to pass slightly different arguments to
@@ -33,9 +32,9 @@ $ openocd \
 
 The program will block; leave that terminal open.
 
-Now it's a good time to explain what this command is actually doing.
+Now it's a good time to explain what the `openocd` command is actually doing.
 
-I mentioned that the F3 actually has two microcontrollers. One of them is used as a
+I mentioned that the STM32F3DISCOVERY (aka F3) actually has two microcontrollers. One of them is used as a
 programmer/debugger. The part of the board that's used as a programmer is called ST-LINK (that's what
 STMicroelectronics decided to call it). This ST-LINK is connected to the target microcontroller
 using a Serial Wire Debug (SWD) interface (this interface is an ARM standard so you'll run into it
@@ -56,12 +55,12 @@ device (`interface/stlink-v2-1.cfg`) and to expect a STM32F3XX microcontroller
 (`target/stm32f3x.cfg`) to be connected to the ST-LINK.
 
 The OpenOCD output looks like this:
-
 ``` console
-Open On-Chip Debugger 0.9.0 (2016-04-27-23:18)
+$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
 For bug reports, read
-        http://openocd.org/doc/doxygen/bugs.html
+	http://openocd.org/doc/doxygen/bugs.html
 Info : auto-selecting first available session transport "hla_swd". To override use 'transport select <transport>'.
 adapter speed: 1000 kHz
 adapter_nsrst_delay: 100
@@ -70,47 +69,65 @@ none separate
 Info : Unable to match requested speed 1000 kHz, using 950 kHz
 Info : Unable to match requested speed 1000 kHz, using 950 kHz
 Info : clock speed 950 kHz
-Info : STLINK v2 JTAG v27 API v2 SWIM v15 VID 0x0483 PID 0x374B
+Info : STLINK v2 JTAG v37 API v2 SWIM v26 VID 0x0483 PID 0x374B
 Info : using stlink api v2
-Info : Target voltage: 2.919073
+Info : Target voltage: 2.888183
 Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
 ```
 
 The "6 breakpoints, 4 watchpoints" part indicates the debugging features the processor has
 available.
 
-Leave that `openocd` process running, and open a new terminal. Make sure that you are inside the project's `src/05-led-roulette/` directory.
+Leave that `openocd` process running, and in the previous terminal or a new terminal
+**make sure that you are inside the project's `src/05-led-roulette/` directory**.
 
 I mentioned that OpenOCD provides a GDB server so let's connect to that right now:
 
+## Execute GDB
+
+First we need to determine what version of GDB you have that is capable of debugging ARM binaries.
+
+This could be any one of the commands below, try each one:
 ``` console
-$ <gdb> -q target/thumbv7em-none-eabihf/debug/led-roulette
+arm-none-eabi-gdb -q -ex "target remote :3333" target/thumbv7em-none-eabihf/debug/led-roulette
+```
+``` console
+gdb-multiarch -q -ex "target remote :3333" target/thumbv7em-none-eabihf/debug/led-roulette
+```
+``` console
+gdb -q -ex "target remote :3333" target/thumbv7em-none-eabihf/debug/led-roulette
+```
+### **Failing case**
+
+You can detect a failing case if there is a `warning` or `error` after the `Remote debugging using :3333` line:
+```
+$ gdb -q -ex "target remote :3333" target/thumbv7em-none-eabihf/debug/led-roulette
 Reading symbols from target/thumbv7em-none-eabihf/debug/led-roulette...
+Remote debugging using :3333
+warning: Architecture rejected target-supplied description
+Truncated register 16 in remote 'g' packet
 (gdb)
 ```
-
-**NOTE**: `<gdb>` represents a GDB program capable of debugging ARM binaries.
-This could be `arm-none-eabi-gdb`, `gdb-multiarch` or `gdb` depending on your
-system -- you may have to try all three.
-
-This only opens a GDB shell. To actually connect to the OpenOCD GDB server, use the following
-command within the GDB shell:
-
+### **Successful case**
+Successful case 1:
 ```
-(gdb) target remote :3333
+$ arm-none-eabi-gdb -q -ex "target remote :3333" target/thumbv7em-none-eabihf/debug/led-roulette
+Reading symbols from target/thumbv7em-none-eabihf/debug/led-roulette...
+Remote debugging using :3333
+cortex_m_rt::Reset () at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:497
+497     pub unsafe extern "C" fn Reset() -> ! {
+(gdb)
+```
+Successful case 2:
+```
+~/embedded-discovery/src/05-led-roulette (master)
+$ arm-none-eabi-gdb -q -ex "target remote :3333" target/thumbv7em-none-eabihf/debug/led-roulette
+Reading symbols from target/thumbv7em-none-eabihf/debug/led-roulette...
 Remote debugging using :3333
 0x00000000 in ?? ()
+(gdb)
 ```
-
-**NOTE**: If you are getting errors like `undefined debug reason 7 - target needs reset`, you can try running `monitor reset halt` as described [here](https://stackoverflow.com/questions/38994596/reason-7-target-needs-reset-unreliable-debugging-setup).
-
-**NOTE**: If the debugger is still not connecting to the OpenOCD server, then you may need to try using `arm-none-eabi-gdb` instead of the `gdb` command, as described above.
-
-By default OpenOCD's GDB server listens on TCP port 3333 (localhost). This command is connecting to
-that port.
-
-After entering this command, you'll see new output in the OpenOCD terminal:
-
+In both failing and successful cases you should see new output in the **OpenOCD terminal**, something like the following:
 ``` diff
  Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
 +Info : accepting 'gdb' connection on tcp/3333
@@ -118,18 +135,25 @@ After entering this command, you'll see new output in the OpenOCD terminal:
 +Info : flash size = 256kbytes
 ```
 
+**NOTE**: If you are getting an error like `undefined debug reason 7 - target needs reset`, you can try running `monitor reset halt` as described [here](https://stackoverflow.com/questions/38994596/reason-7-target-needs-reset-unreliable-debugging-setup).
+
+By default OpenOCD's GDB server listens on TCP port 3333 (localhost). This command is connecting to
+that port.
+
+## Flash the device
+
 Almost there. To flash the device, we'll use the `load` command inside the GDB shell:
 
 ```
 (gdb) load
 Loading section .vector_table, size 0x194 lma 0x8000000
-Loading section .text, size 0x21cc lma 0x8000194
-Loading section .rodata, size 0x594 lma 0x8002360
-Start address 0x08000194, load size 10484
-Transfer rate: 16 KB/sec, 3494 bytes/write.
+Loading section .text, size 0x20ec lma 0x8000194
+Loading section .rodata, size 0x514 lma 0x8002280
+Start address 0x08000194, load size 10132
+Transfer rate: 17 KB/sec, 3377 bytes/write.
 ```
 
-And that's it. You'll also see new output in the OpenOCD terminal.
+You'll also see new output in the OpenOCD terminal, something like:
 
 ``` diff
  Info : flash size = 256kbytes

--- a/src/05-led-roulette/the-challenge.md
+++ b/src/05-led-roulette/the-challenge.md
@@ -29,7 +29,7 @@ manually on each GDB session.
 Using an editor create `openocd.gdb` in the root of the Cargo project, right next to the `Cargo.toml`:
 
 ``` console
-vi openocd.gdb
+nano openocd.gdb
 ```
 
 And add the following text:
@@ -48,7 +48,7 @@ also add a `[build]` section with `thumbv7em-none-eabihf` so we don't
 have to specify the `--target` when using `cargo build` or `cargo run`:
 
 ``` console
-vi .cargo/config
+nano .cargo/config
 ```
 
 Replacing the contents with the text below. This adds `-x openocd.gdb` to

--- a/src/05-led-roulette/the-led-and-delay-abstractions.md
+++ b/src/05-led-roulette/the-led-and-delay-abstractions.md
@@ -40,46 +40,55 @@ fn main() -> ! {
 Now build it:
 
 ``` console
-$ cargo build --target thumbv7em-none-eabihf
+cargo build --target thumbv7em-none-eabihf
 ```
 
 > **NOTE** It's possible to forget to rebuild the program *before* starting a GDB session; this
-> omission can lead to very confusing debug sessions. To avoid this problem you can call `cargo run`
-> instead of `cargo build`; `cargo run` will build *and* start a debug session ensuring you never
-> forget to recompile your program.
+> omission can lead to very confusing debug sessions. To avoid this problem you can call just `cargo run`
+> instead of `cargo build`; `cargo run`. The `cargo run` command will build *and* start a debug
+> session ensuring you never forget to recompile your program.
 
 Now, we'll repeat the flashing procedure that we did in the previous section:
 
 ``` console
+cargo run --target thumbv7em-none-eabihf
+```
+
+Which results in something like:
+``` console
 $ cargo run --target thumbv7em-none-eabihf
     Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-     Running `arm-none-eabi-gdb -q ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette`
-Reading symbols from ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette...
+     Running `arm-none-eabi-gdb -q ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette`
+Reading symbols from ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette...
+
 (gdb) target remote :3333
 Remote debugging using :3333
-led_roulette::__cortex_m_rt_main_trampoline () at src/05-led-roulette/src/main.rs:7
+led_roulette::__cortex_m_rt_main_trampoline () at ~/embedded-discovery/src/05-led-roulette/src/main.rs:7
 7       #[entry]
 
 (gdb) load
 Loading section .vector_table, size 0x194 lma 0x8000000
-Loading section .text, size 0x51f0 lma 0x8000194
-Loading section .rodata, size 0xbd0 lma 0x8005384
-Start address 0x08000194, load size 24404
-Transfer rate: 21 KB/sec, 6101 bytes/write.
+Loading section .text, size 0x52c0 lma 0x8000194
+Loading section .rodata, size 0xb50 lma 0x8005454
+Start address 0x08000194, load size 24484
+Transfer rate: 21 KB/sec, 6121 bytes/write.
 
 (gdb) break main
-Breakpoint 1 at 0x8000202: file src/05-led-roulette/src/main.rs, line 7.
+Breakpoint 1 at 0x8000202: file ~/embedded-discovery/src/05-led-roulette/src/main.rs, line 7.
 Note: automatically using hardware breakpoints for read-only addresses.
 
 (gdb) continue
 Continuing.
 
-Breakpoint 1, led_roulette::__cortex_m_rt_main_trampoline () at src/05-led-roulette/src/main.rs:7
+Breakpoint 1, led_roulette::__cortex_m_rt_main_trampoline ()
+    at ~/embedded-discovery/src/05-led-roulette/src/main.rs:7
 7       #[entry]
 
 (gdb) step
-led_roulette::__cortex_m_rt_main () at src/05-led-roulette/src/main.rs:9
+led_roulette::__cortex_m_rt_main () at ~/embedded-discovery/src/05-led-roulette/src/main.rs:9
 9           let (mut delay, mut leds): (Delay, LedArray) = aux5::init();
+
+(gdb) 
 ```
 
 OK. Let's step through the code. This time, we'll use the `next` command instead of `step`. The
@@ -398,10 +407,10 @@ the led will now be on for 2 seconds then off for 2 seconds.
 
 ``` console
 $ cargo run --target thumbv7em-none-eabihf
-   Compiling led-roulette v0.2.0 (~/prgs/rust/tutorial/embedded-discovery/src/05-led-roulette)
+   Compiling led-roulette v0.2.0 (~/embedded-discovery/src/05-led-roulette)
     Finished dev [unoptimized + debuginfo] target(s) in 0.18s
-     Running `arm-none-eabi-gdb -q ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette`
-Reading symbols from ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette...
+     Running `arm-none-eabi-gdb -q ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette`
+Reading symbols from ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette...
 
 (gdb) target remote :3333
 Remote debugging using :3333
@@ -555,7 +564,7 @@ Program received signal SIGINT, Interrupt.
 1046    pub unsafe fn read_volatile<T>(src: *const T) -> T {
 
 (gdb) q
-Detaching from program: ~/prgs/rust/tutorial/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette, Remote target
+Detaching from program: ~/embedded-discovery/target/thumbv7em-none-eabihf/debug/led-roulette, Remote target
 Ending remote debugging.
 [Inferior 1 (Remote target) detached]
 ```


### PR DESCRIPTION
Cargo.toml to use stm32f3-discovery v0.6.0 crate.

Update `.md` files with additional information and to make console
commands amenable to copy/paste operations.