### PR TITLE
Fix small typo in Linux setup

### DIFF
--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -136,7 +136,7 @@ It should result in something like:
 $ lsusb | grep ST-LINK
 Bus 003 Device 003: ID 0483:374b STMicroelectronics ST-LINK/V2.1
 ```
-So the `idProduct` is `0483` and `idVendor` is `374b`.
+So the `idVendor` is `0483` and `idProduct` is `374b`.
 
 ### Create `/etc/udev/rules.d/99-openocd.rules`:
 ``` console


### PR DESCRIPTION
My device has identical `idProduct` and `idVendor` values to the one used for the documentation.

`lsusb | grep STM` outputs:
```
Bus 003 Device 033: ID 0483:374b STMicroelectronics ST-LINK/V2.1
```

The verbose version, `lsusb -v`, outputs
```
  ...
  idVendor           0x0483 STMicroelectronics
  idProduct          0x374b ST-LINK/V2.1
  ...
```

Which leads me to the belief that the first value in the short output is the vendor and the latter is the product.