### PR TITLE
Fix breaking change in  cortex-m 0.5.11.

### DIFF
--- a/src/11-usart/auxiliary/Cargo.toml
+++ b/src/11-usart/auxiliary/Cargo.toml
@@ -5,7 +5,7 @@ name = "aux11"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.5.6"
+cortex-m = "=0.5.6" # 0.5.11 introduces a breaking change.  Use 0.5.6, since we know it works for this example
 cortex-m-rt = "0.6.3"
 panic-itm = "0.4.0"
 

--- a/src/14-i2c/auxiliary/Cargo.toml
+++ b/src/14-i2c/auxiliary/Cargo.toml
@@ -5,7 +5,7 @@ name = "aux14"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.6.3"
+cortex-m = "=0.5.6"
 cortex-m-rt = "0.6.3"
 panic-itm = "0.4.0"
 

--- a/src/15-led-compass/auxiliary/Cargo.toml
+++ b/src/15-led-compass/auxiliary/Cargo.toml
@@ -5,7 +5,7 @@ name = "aux15"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.6.3"
+cortex-m = "=0.5.6"
 cortex-m-rt = "0.6.3"
 panic-itm = "0.4.0"
 


### PR DESCRIPTION
Fix it by sticking with cortex-m 0.5.6.

See discussion at #327.  This is a much simpler (and certainly more hackish) solution than is proposed in #267.  But it doesn't require `unsafe` code nor a custom `memory.x` file, and might fill the gap until the book is rewritten.