### PR TITLE
Solution proposed in 05-led-roulette/my-solution doesn't quite agree with the timing diagram

### DIFF
--- a/src/05-led-roulette/my-solution.md
+++ b/src/05-led-roulette/my-solution.md
@@ -16,6 +16,8 @@ fn main() -> ! {
     let (mut delay, mut leds): (Delay, LedArray) = aux5::init();
 
     let ms = 50_u8;
+
+    leds[0].on().ok();
     loop {
         for curr in 0..8 {
             let next = (curr + 1) % 8;


### PR DESCRIPTION
leds[0] (red) should be on at the step 0.