### PR TITLE
Clean up warning on unused result

### DIFF
--- a/src/16-punch-o-meter/auxiliary/src/lib.rs
+++ b/src/16-punch-o-meter/auxiliary/src/lib.rs
@@ -35,7 +35,7 @@ pub fn init() -> (Lsm303dlhc, Delay, MonoTimer, ITM) {
     let mut nss = gpioe
         .pe3
         .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
-    nss.set_high();
+    nss.set_high().unwrap();
 
     let mut gpiob = dp.GPIOB.split(&mut rcc.ahb);
     let scl = gpiob.pb6.into_af4(&mut gpiob.moder, &mut gpiob.afrl);


### PR DESCRIPTION
I would prefer the example code not to contain unused results. This cleans up the actually one and only warning on an unused result.
```bash
$ cargo build --target thumbv7em-none-eabihf
[...]
warning: unused `Result` that must be used
  --> src/16-punch-o-meter/auxiliary/src/lib.rs:38:5
   |
38 |     nss.set_high();
   |     ^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled

warning: 1 warning emitted
[...]
```