### PR TITLE
Remove exemption for print.html from link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build book
         run: mkdir target && mdbook build
       - name: Check links
-        run: linkchecker --ignore-url "print.html" book
+        run: linkchecker book
 
       - name: Deploy book
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
This is a remake of https://github.com/rust-embedded/discovery/pull/255 for the actual GitHub Actions.

The need for keeping this exemption around no longer exists since a while. Let's remove it and pave the way for closing https://github.com/rust-embedded/discovery/pull/255.

Link checking passes without any issues with the current release of `mdbook`:
```bash
$ mdbook --version
mdbook v0.4.8
$ mdbook build
2021-05-31 22:34:19 [INFO] (mdbook::book): Book building has started
2021-05-31 22:34:19 [INFO] (mdbook::book): Running the html backend
$ linkchecker book
INFO linkcheck.cmdline 2021-05-31 22:34:25,644 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 10.0.1
Copyright (C) 2000-2016 Bastian Kleineidam, 2010-2021 LinkChecker Authors
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it under
certain conditions. Look at the file `LICENSE' within this distribution.
Get the newest version at https://linkchecker.github.io/linkchecker/
Write comments and bugs to https://github.com/linkchecker/linkchecker/issues

Start checking at 2021-05-31 22:34:25+002
10 threads active,   120 links queued,   84 links in 214 URLs checked, runtime 1 seconds

URL        `../appendix/2-how-to-use-gdb'
Name       `How to use GDB'
Parent URL file:///[...]/discovery/book/05-led-roulette/debug-it.html, line 420, col 98
Real URL   file:///[...]/discovery/book/appendix/2-how-to-use-gdb/
Check time 0.003 seconds
Warning    [file-missing-slash] Added trailing slash to
           directory.
Result     Valid: directory

Statistics:
Downloaded: 2.15MB.
Content types: 34 image, 87 text, 0 video, 0 audio, 158 application, 0 mail and 170 other.
URL lengths: min=8, max=180, avg=66.

That's it. 449 links in 449 URLs checked. 1 warning found. 0 errors found.
Stopped checking at 2021-05-31 22:34:30+002 (4 seconds)
```