### PR TITLE
Clean up warning from linkchecker

### DIFF
--- a/src/05-led-roulette/debug-it.md
+++ b/src/05-led-roulette/debug-it.md
@@ -307,7 +307,7 @@ At any point you can leave the TUI mode using the following command:
 [gdb-dashboard]: https://github.com/cyrus-and/gdb-dashboard#gdb-dashboard
 
 Don't close OpenOCD though! We'll use it again and again later on. It's better
-just to leave it running. If you want to learn more about what GDB can do, check out the section [How to use GDB](../appendix/2-how-to-use-gdb).
+just to leave it running. If you want to learn more about what GDB can do, check out the section [How to use GDB](../appendix/2-how-to-use-gdb/).
 
 
 What's next? The high level API I promised.


### PR DESCRIPTION
Linkchecker warned about this link to a directory without a trailing slash. Seen while working on https://github.com/rust-embedded/discovery/pull/346.

Link checking now completes without any warnings:
```bash
$ mdbook build
2021-05-31 22:49:44 [INFO] (mdbook::book): Book building has started
2021-05-31 22:49:44 [INFO] (mdbook::book): Running the html backend
$ linkchecker book
INFO linkcheck.cmdline 2021-05-31 22:49:55,452 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 10.0.1
[...]
Start checking at 2021-05-31 22:49:55+002
10 threads active,   162 links queued,  205 links in 377 URLs checked, runtime 1 seconds

Statistics:
Downloaded: 2.15MB.
Content types: 34 image, 87 text, 0 video, 0 audio, 158 application, 0 mail and 170 other.
URL lengths: min=8, max=180, avg=66.

That's it. 449 links in 449 URLs checked. 0 warnings found. 0 errors found.
Stopped checking at 2021-05-31 22:50:00+002 (4 seconds)
```