### PR TITLE
DOC Minor fixes

### DIFF
--- a/src/07-registers/rtrm.md
+++ b/src/07-registers/rtrm.md
@@ -37,7 +37,7 @@ peripheral, that table is in:
 
 > Section 11.4.12 GPIO register map - Page 243
 
-'BSRR' is the register which we will be using to set/reset. It's offset value is '0x18' from the base address 
+'BSRR' is the register which we will be using to set/reset. Its offset value is '0x18' from the base address 
 of the 'GPIOE'. We can look up BSRR in the reference manual. 
 GPIO Registers -> GPIO port bit set/reset register (GPIOx_BSRR).
 

--- a/src/07-registers/rtrm.md
+++ b/src/07-registers/rtrm.md
@@ -37,8 +37,9 @@ peripheral, that table is in:
 
 > Section 11.4.12 GPIO register map - Page 243
 
-We are interested in the register that's at an offset of `0x18` from the base address of the `GPIOE`
-peripheral. According to the table, that would be the register `BSRR`.
+'BSRR' is the register which we will be using to set/reset. It's offset value is '0x18' from the base address 
+of the 'GPIOE'. We can look up BSRR in the reference manual. 
+GPIO Registers -> GPIO port bit set/reset register (GPIOx_BSRR).
 
 Now we need to jump to the documentation of that particular register. It's a few pages above in:
 


### PR DESCRIPTION
### What does this implement/fix?
This is a minor change in the RTRM Section 7.1 which makes it easy to find the BSRR register.
The way we can reach to BSRR register and it's offset value 0x18.