### PR TITLE
Streamline LED roulette example

### DIFF
--- a/src/05-led-roulette/auxiliary/Cargo.toml
+++ b/src/05-led-roulette/auxiliary/Cargo.toml
@@ -9,7 +9,7 @@ name = "aux5"
 version = "0.2.0"
 
 [dependencies]
-cortex-m = "0.6.4"
-cortex-m-rt = "0.6.13"
-stm32f3-discovery = "0.6.0"
+cortex-m = "0.7.2"
+cortex-m-rt = "0.6.14"
+stm32f3-discovery = "0.7.0"
 panic-itm = "0.4.2"

--- a/src/05-led-roulette/auxiliary/src/lib.rs
+++ b/src/05-led-roulette/auxiliary/src/lib.rs
@@ -14,13 +14,13 @@ pub use stm32f3xx_hal::{
     delay::Delay,
     gpio::{gpioe, Output, PushPull},
     hal::blocking::delay::DelayMs,
-    stm32,
+    pac,
 };
 
 pub type LedArray = [Switch<gpioe::PEx<Output<PushPull>>, ActiveHigh>; 8];
 
 pub fn init() -> (Delay, LedArray) {
-    let device_periphs = stm32::Peripherals::take().unwrap();
+    let device_periphs = pac::Peripherals::take().unwrap();
     let mut reset_and_clock_control = device_periphs.RCC.constrain();
 
     let core_periphs = cortex_m::Peripherals::take().unwrap();

--- a/src/05-led-roulette/debug-it.md
+++ b/src/05-led-roulette/debug-it.md
@@ -54,10 +54,10 @@ invokes a subroutine call to the `main` function using an ARM branch and link in
 ```
 (gdb) disassemble /m
 Dump of assembler code for function main:
-8       #[entry]
+7       #[entry]
    0x080001ec <+0>:     push    {r7, lr}
    0x080001ee <+2>:     mov     r7, sp
-=> 0x080001f0 <+4>:     bl      0x80001f6 <hello_world::__cortex_m_rt_main>
+=> 0x080001f0 <+4>:     bl      0x80001f6 <_ZN12led_roulette18__cortex_m_rt_main17he61ef18c060014a5E>
    0x080001f4 <+8>:     udf     #254    ; 0xfe
 
 End of assembler dump.

--- a/src/05-led-roulette/examples/my-solution.rs
+++ b/src/05-led-roulette/examples/my-solution.rs
@@ -1,0 +1,22 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use aux5::{Delay, DelayMs, LedArray, OutputSwitch, entry};
+
+#[entry]
+fn main() -> ! {
+    let (mut delay, mut leds): (Delay, LedArray) = aux5::init();
+
+    let ms = 50_u8;
+    loop {
+        for curr in 0..8 {
+            let next = (curr + 1) % 8;
+
+            leds[next].on().ok();
+            delay.delay_ms(ms);
+            leds[curr].off().ok();
+            delay.delay_ms(ms);
+        }
+    }
+}

--- a/src/05-led-roulette/examples/the-led-and-delay-abstractions.rs
+++ b/src/05-led-roulette/examples/the-led-and-delay-abstractions.rs
@@ -1,0 +1,20 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use aux5::{entry, Delay, DelayMs, LedArray, OutputSwitch};
+
+#[entry]
+fn main() -> ! {
+    let (mut delay, mut leds): (Delay, LedArray) = aux5::init();
+
+    let half_period = 500_u16;
+
+    loop {
+        leds[0].on().ok();
+        delay.delay_ms(half_period);
+
+        leds[0].off().ok();
+        delay.delay_ms(half_period);
+    }
+}

--- a/src/05-led-roulette/my-solution.md
+++ b/src/05-led-roulette/my-solution.md
@@ -5,29 +5,7 @@ What solution did you come up with?
 Here's mine:
 
 ``` rust
-#![deny(unsafe_code)]
-#![no_main]
-#![no_std]
-
-use aux5::{Delay, DelayMs, LedArray, OutputSwitch, entry};
-
-#[entry]
-fn main() -> ! {
-    let (mut delay, mut leds): (Delay, LedArray) = aux5::init();
-
-    let ms = 50_u8;
-    loop {
-        for curr in 0..8 {
-            let next = (curr + 1) % 8;
-
-            leds[next].on().ok();
-            delay.delay_ms(ms);
-            leds[curr].off().ok();
-            delay.delay_ms(ms);
-        }
-    }
-}
-
+{{#include examples/my-solution.rs}}
 ```
 
 One more thing! Check that your solution also works when compiled in "release" mode:

--- a/src/05-led-roulette/the-led-and-delay-abstractions.md
+++ b/src/05-led-roulette/the-led-and-delay-abstractions.md
@@ -14,27 +14,7 @@ and exposes two methods: `on` and `off` which can be used to turn the LED on or 
 Let's try out these two abstractions by modifying the starter code to look like this:
 
 ``` rust
-#![deny(unsafe_code)]
-#![no_main]
-#![no_std]
-
-use aux5::{entry, Delay, DelayMs, LedArray, OutputSwitch};
-
-#[entry]
-fn main() -> ! {
-    let (mut delay, mut leds): (Delay, LedArray) = aux5::init();
-
-    let half_period = 500_u16;
-
-    loop {
-        leds[0].on().ok();
-        delay.delay_ms(half_period);
-
-        leds[0].off().ok();
-        delay.delay_ms(half_period);
-    }
-}
-
+{{#include examples/the-led-and-delay-abstractions.rs}}
 ```
 
 Now build it:


### PR DESCRIPTION
This PR brings the LED roulette to up-to-date dependencies and factors out the examples, so that they could be tested in CI.

I wanted to update all examples at once in the first place. But this did not get to the pace I wanted, so I will attempt this one after another.