### PR TITLE
Fix instructions for installting GDB on Fedora

### DIFF
--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -42,12 +42,10 @@ sudo apt-get install \
 
 ### Fedora 23 or newer
 
-> **NOTE** `arm-none-eabi-gdb` is the GDB command you'll use to debug your ARM
-> Cortex-M programs
+Install GDB as described in [Other distros](#other-distros) and the following packages:
 
 ``` console
 sudo dnf install \
-  arm-none-eabi-gdb \
   minicom \
   openocd
 ```


### PR DESCRIPTION
The package `arm-none-eabi-gdb` is no longer provided by Fedora as stated in #364. So let's guide Fedora uses to _Other distros_ then and use a pre-built toolchain provided by ARM. This is also the recommendation from the [issue at Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=1859627#c26).