### PR TITLE
Fix typo in 05-led-roulette/the-challenge

### DIFF
--- a/src/05-led-roulette/the-challenge.md
+++ b/src/05-led-roulette/the-challenge.md
@@ -73,7 +73,7 @@ step
 
 Now we need to modify the `../.cargo/config.toml` file to execute `../openocd.gdb`
 ``` console
-nano ../openocd.gdb
+nano ../.cargo/config.toml
 ```
 
 Edit your `runner` command ` -x ../openocd.gdb`.


### PR DESCRIPTION
The text said to modify `../.cargo/config.toml`, but the command was given to modify `../openocd.gdb`.