### PR TITLE
Terminology section in chapter 4

### DIFF
--- a/src/04-meet-your-hardware/terminology.md
+++ b/src/04-meet-your-hardware/terminology.md
@@ -1,0 +1,67 @@
+# Rust Embedded terminology
+Before we dive into programming the micro:bit let's have a quick look
+at the libraries and terminology that will be important for all of the
+future chapters.
+
+## Abstraction layers
+For any fully supported microcontroller/board with a microcontroller
+you will usually hear the following terms being used for their levels
+of abstraction:
+1. The Peripheral Access Crate (PAC), its job is to provide a safe (ish)
+   direct interface to the peripherals of the chip, allowing you to configure
+   every last bit however you want (of course also in wrong ways). Usually
+   you only ever have to deal with the PAC if either the layers that are
+   higher up don't fulfill your needs or when you are developing them.
+   The PAC we are (implicitly) going to use is either the one for the [nRF52]
+   or for the [nRF51].
+2. The Hardware Abstraction Layer (HAL), its job is to build up on top of
+   the chip's PAC and provide an abstraction that is actually usable for
+   someone who does not know about all the special behaviour of this chip.
+   Usually they abstract a whole peripheral, e.g. a USB interface,
+   away into just a few structs or traits with some functions on them you
+   can use to send data around etc. We are going to use the [nRF52-hal]
+   or the [nRF51-hal] respectively.
+3. The Board Support Crate (BSP), its job is to abstract a whole board
+   (such as the micro:bit) away at once. That means it has to provide
+   abstractions to use both the microcontroller as well als the sensors,
+   LEDs etc. that might be present on the board. Quite often (especially
+   with custom made boards) you will just be working with a HAL for the
+   chip and build the drivers for the sensors either yourself or
+   search for them on crates.io, luckily for us though the micro:bit
+   does actually have a [BSP] so we are going to use that on top of our
+   HAL as well.
+
+[nrF52]: https://crates.io/crates/nrf52833-pac
+[nrF51]: https://crates.io/crates/nrf51
+[nrF52-hal]: https://crates.io/crates/nrf52833-hal
+[nrF51-hal]: https://crates.io/crates/nrf51-hal
+[BSP]: https://crates.io/crates/microbit
+
+## Unifying the layers
+
+Next we are going to have a look at a very central piece of software
+in the Rust Embedded world, [embedded-hal]. As it name suggests it
+relates to the 2nd level of abstraction we got to know, the HALs.
+The idea behind [embedded-hal] is to provide a set of traits that
+describe behaviour which is usually shared across all implementations
+of a specific peripheral in all the HALs. For example one would always
+expect to have functions that are capable of turning the power on a pin
+either on or off, for example to switch an LED on and off on the board.
+This allows us to write a driver for, say a temperature sensor, that
+can be used on any chip which implements the [embedded-hal] traits,
+simply by writing the driver in such a way that it only relies on the
+[embedded-hal] traits. Drivers that are written in such a way are called
+platform agnostic and luckily for us most of the drivers on crates.io
+are actually platform agnostic.
+
+[embedded-hal]: https://crates.io/crates/embedded-hal
+
+
+## Further reading
+
+If you want to learn more about these levels of abstraction Franz Skarman,
+aka. [TheZoq2], held a talk about this topic during Oxidize 2020, called
+[An Overview of the Embedded Rust Ecosystem].
+
+[TheZoq2]: https://github.com/TheZoq2/
+[An Overview of the Embedded Rust Ecosystem]: https://www.youtube.com/watch?v=vLYit_HHPaY

--- a/src/04-meet-your-hardware/terminology.md
+++ b/src/04-meet-your-hardware/terminology.md
@@ -21,13 +21,13 @@ of abstraction:
    away into just a few structs or traits with some functions on them you
    can use to send data around etc. We are going to use the [nRF52-hal]
    or the [nRF51-hal] respectively.
-3. The Board Support Crate (BSP), its job is to abstract a whole board
+3. The Board Support Crate (historically called Board Support Package, or BSP), its job is to abstract a whole board
    (such as the micro:bit) away at once. That means it has to provide
    abstractions to use both the microcontroller as well als the sensors,
    LEDs etc. that might be present on the board. Quite often (especially
    with custom made boards) you will just be working with a HAL for the
    chip and build the drivers for the sensors either yourself or
-   search for them on crates.io, luckily for us though the micro:bit
+   search for them on crates.io. Luckily for us though, the micro:bit
    does actually have a [BSP] so we are going to use that on top of our
    HAL as well.
 
@@ -40,17 +40,17 @@ of abstraction:
 ## Unifying the layers
 
 Next we are going to have a look at a very central piece of software
-in the Rust Embedded world, [embedded-hal]. As it name suggests it
-relates to the 2nd level of abstraction we got to know, the HALs.
-The idea behind [embedded-hal] is to provide a set of traits that
+in the Rust Embedded world: `[embedded-hal]`. As its name suggests it
+relates to the 2nd level of abstraction we got to know: the HALs.
+The idea behind `[embedded-hal]` is to provide a set of traits that
 describe behaviour which is usually shared across all implementations
 of a specific peripheral in all the HALs. For example one would always
 expect to have functions that are capable of turning the power on a pin
-either on or off, for example to switch an LED on and off on the board.
+either on or off. For example to switch an LED on and off on the board.
 This allows us to write a driver for, say a temperature sensor, that
-can be used on any chip which implements the [embedded-hal] traits,
+can be used on any chip for which an implementation of the `[embedded-hal]` traits exists,
 simply by writing the driver in such a way that it only relies on the
-[embedded-hal] traits. Drivers that are written in such a way are called
+`[embedded-hal]` traits. Drivers that are written in such a way are called
 platform agnostic and luckily for us most of the drivers on crates.io
 are actually platform agnostic.
 
@@ -59,8 +59,8 @@ are actually platform agnostic.
 
 ## Further reading
 
-If you want to learn more about these levels of abstraction Franz Skarman,
-aka. [TheZoq2], held a talk about this topic during Oxidize 2020, called
+If you want to learn more about these levels of abstraction, Franz Skarman,
+a.k.a. [TheZoq2], held a talk about this topic during Oxidize 2020, called
 [An Overview of the Embedded Rust Ecosystem].
 
 [TheZoq2]: https://github.com/TheZoq2/

--- a/src/04-meet-your-hardware/terminology.md
+++ b/src/04-meet-your-hardware/terminology.md
@@ -17,10 +17,9 @@ of abstraction:
 2. The Hardware Abstraction Layer (HAL), its job is to build up on top of
    the chip's PAC and provide an abstraction that is actually usable for
    someone who does not know about all the special behaviour of this chip.
-   Usually they abstract a whole peripheral, e.g. a USB interface,
-   away into just a few structs or traits with some functions on them you
-   can use to send data around etc. We are going to use the [nRF52-hal]
-   or the [nRF51-hal] respectively.
+   Usually they abstract whole peripherals away into single structs that can
+   for example be used to send data around via the peripheral. We are
+   going to use the [nRF52-hal] or the [nRF51-hal] respectively.
 3. The Board Support Crate (historically called Board Support Package, or BSP), its job is to abstract a whole board
    (such as the micro:bit) away at once. That means it has to provide
    abstractions to use both the microcontroller as well als the sensors,

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Meet your hardware](04-meet-your-hardware/README.md)
     - [micro:bit v2](04-meet-your-hardware/microbit-v2.md)
     - [micro:bit v1](04-meet-your-hardware/microbit-v1.md)
+    - [Rust Embedded terminology](04-meet-your-hardware/terminology.md)
 - [LED roulette](05-led-roulette/README.md)
     - [Build it](05-led-roulette/build-it.md)
     - [Flash it](05-led-roulette/flash-it.md)


### PR DESCRIPTION
I feel like a more fleshed out terminology section is both necessary and fits into chapter 4 better than chapter 5, especially since
we are now dealing with BSPs as well.