### PR TITLE
Update the troubleshooting section for micro:bit

### DIFF
--- a/src/appendix/1-general-troubleshooting/README.md
+++ b/src/appendix/1-general-troubleshooting/README.md
@@ -1,129 +1,17 @@
 # General troubleshooting
 
-## OpenOCD problems
+## `cargo-embed` problems
+Most `cargo-embed` problems are either related to not having installed the `udev`
+rules properly or having selected the wrong chip configuration in `Embed.toml` so
+make sure you got both of those right.
 
-### can't connect to OpenOCD - "Error: open failed"
+If the above does not work out for you, you can open an issue in the [`discovery` issue tracker].
+Alternatively you can also visit the [Rust Embedded matrix channel] or the [probe-rs matrix channel]
+and ask for help there.
 
-#### Symptoms
-
-Upon trying to establish a *new connection* with the device you get an error
-that looks like this:
-
-```
-$ openocd -f (..)
-(..)
-Error: open failed
-in procedure 'init'
-in procedure 'ocd_bouncer'
-```
-
-#### Cause + Fix
-
-- All: The device is not (properly) connected. Check the USB connection using
-  `lsusb` or the Device Manager.
-- Linux: You may not have enough permission to open the device. Try again with
-  `sudo`. If that works, you can use [these instructions] to make OpenOCD work
-  without root privilege.
-- Windows: You are probably missing the ST-LINK USB driver. Installation
-  instructions [here].
-
-[these instructions]: ../../03-setup/linux.md#udev-rules
-[here]: ../../03-setup/windows.md#st-link-usb-driver
-
-### can't connect to OpenOCD - "Polling again in X00ms"
-
-#### Symptoms
-
-Upon trying to establish a *new connection* with the device you get an error
-that looks like this:
-
-```
-$ openocd -f (..)
-(..)
-Error: jtag status contains invalid mode value - communication failure
-Polling target stm32f3x.cpu failed, trying to reexamine
-Examination failed, GDB will be halted. Polling again in 100ms
-Info : Previous state query failed, trying to reconnect
-Error: jtag status contains invalid mode value - communication failure
-Polling target stm32f3x.cpu failed, trying to reexamine
-Examination failed, GDB will be halted. Polling again in 300ms
-Info : Previous state query failed, trying to reconnect
-```
-
-#### Cause
-
-The microcontroller may have get stuck in some tight infinite loop or it may be
-continuously raising an exception, e.g. the exception handler is raising an
-exception.
-
-#### Fix
-
-- Close OpenOCD, if running
-- Press and hold the reset (black) button
-- Launch the OpenOCD command
-- Now, release the reset button
-
-
-### OpenOCD connection lost - "Polling again in X00ms"
-
-#### Symptoms
-
-A *running* OpenOCD session suddenly errors with:
-
-```
-# openocd -f (..)
-Error: jtag status contains invalid mode value - communication failure
-Polling target stm32f3x.cpu failed, trying to reexamine
-Examination failed, GDB will be halted. Polling again in 100ms
-Info : Previous state query failed, trying to reconnect
-Error: jtag status contains invalid mode value - communication failure
-Polling target stm32f3x.cpu failed, trying to reexamine
-Examination failed, GDB will be halted. Polling again in 300ms
-Info : Previous state query failed, trying to reconnect
-```
-
-#### Cause
-
-The USB connection was lost.
-
-#### Fix
-
-- Close OpenOCD
-- Disconnect and re-connect the USB cable.
-- Re-launch OpenOCD
-
-### Can't flash the device - "Ignoring packet error, continuing..."
-
-#### Symptoms
-
-While flashing the device, you get:
-
-```
-$ arm-none-eabi-gdb $file
-Start address 0x8000194, load size 31588
-Transfer rate: 22 KB/sec, 5264 bytes/write.
-Ignoring packet error, continuing...
-Ignoring packet error, continuing...
-```
-
-#### Cause
-
-Closed `itmdump` while a program that "printed" to the ITM was running. The
-current GDB session will appear to work normally, just without ITM output but
-the next GDB session will error with the message that was shown in the previous
-section.
-
-Or, `itmdump` was called **after** the `monitor tpiu` was issued thus making
-`itmdump` delete the file / named-pipe that OpenOCD was writing to.
-
-#### Fix
-
-- Close/kill GDB, OpenOCD and `itmdump`
-- Remove the file / named-pipe that `itmdump` was using (for example,
-  `itm.txt`).
-- Launch OpenOCD
-- Then, launch `itmdump`
-- Then, launch the GDB session that executes the `monitor tpiu` command.
+[`discovery` issue tracker]: https://github.com/rust-embedded/discovery/issues
+[Rust Embedded matrix channel]: https://matrix.to/#/#rust-embedded:matrix.org
+[probe-rs matrix channel]: https://matrix.to/#/#probe-rs:matrix.org
 
 ## Cargo problems
 
@@ -156,15 +44,17 @@ To learn more, run the command again with --verbose.
 
 #### Cause
 
-You are using a toolchain older than `nightly-2018-04-08` and forgot to call `rustup target add
-thumbv7em-none-eabihf`.
+You forgot to install the proper target for your microcontroller (`thumbv7em-none-eabihf` for v2
+and `thumbv6m-none-eabi` for v1).
 
 #### Fix
 
-Update your nightly and install the `thumbv7em-none-eabihf` target.
+Install the proper target.
 
 ``` console
-$ rustup update nightly
-
+# micro:bit v2
 $ rustup target add thumbv7em-none-eabihf
+
+# micro:bit v1
+$ rustup target add thumbv6m-none-eabi
 ```

--- a/src/appendix/1-general-troubleshooting/README.md
+++ b/src/appendix/1-general-troubleshooting/README.md
@@ -2,7 +2,7 @@
 
 ## `cargo-embed` problems
 Most `cargo-embed` problems are either related to not having installed the `udev`
-rules properly or having selected the wrong chip configuration in `Embed.toml` so
+rules properly (on Linux) or having selected the wrong chip configuration in `Embed.toml` so
 make sure you got both of those right.
 
 If the above does not work out for you, you can open an issue in the [`discovery` issue tracker].

--- a/src/appendix/2-how-to-use-gdb/README.md
+++ b/src/appendix/2-how-to-use-gdb/README.md
@@ -1,6 +1,6 @@
 # How to use GDB
 
-Below are some useful GDB commands that can help us debug our programs. This assumes you have [flashed a program](../../05-led-roulette/flash-it.md) onto your microcontroller and attached to an OpenOCD session.
+Below are some useful GDB commands that can help us debug our programs. This assumes you have [flashed a program](../../05-led-roulette/flash-it.md) onto your microcontroller and attached GDB to a `cargo-embed` session.
 
 ## General Debugging
 
@@ -42,7 +42,7 @@ Below are some useful GDB commands that can help us debug our programs. This ass
 
 * `print /$f $data` - Print the value contained by the variable `$data`. Optionally format the output with `$f`, which can include:
     ```txt
-    x: hexadecimal 
+    x: hexadecimal
     d: signed decimal
     u: unsigned decimal
     o: octal
@@ -67,7 +67,7 @@ Below are some useful GDB commands that can help us debug our programs. This ass
     * `info address GPIOC`: Print the memory address of the variable `GPIOC`
 * `info variables $regex`: Print names and types of global variables matched by `$regex`, omit `$regex` to print all global variables
 * `ptype $data`: Print more detailed information about `$data`
-    * `ptype cp`: Print detailed type information about the variable `cp` 
+    * `ptype cp`: Print detailed type information about the variable `cp`
 
 ### Poking around the Program Stack
 
@@ -81,6 +81,6 @@ Below are some useful GDB commands that can help us debug our programs. This ass
 * `info registers $r`: Print the value of register `$r` in selected frame, omit `$r` for all registers
     * `info registers $sp`: Print the value of the stack pointer register `$sp` in the current frame
 
-### Controlling OpenOCD Remotely
+### Controlling `cargo-embed` Remotely
 
 * `monitor reset`: Reset the CPU, starting execution over again


### PR DESCRIPTION
This mostly just deletes stuff since its related to OpenOCD which we don't have to use anymore with this rewrite (\o/).
I haven't come across any issues with this (that I haven't fixed upstream already) apart from the two things mentioned in the
README. I would expect that this file might grow over time though.