### PR TITLE
Use `cargo embed` instead of `cargo-embed`

### DIFF
--- a/src/03-setup/verify.md
+++ b/src/03-setup/verify.md
@@ -64,10 +64,10 @@ Next run one of these commands:
 ```
 $ # make sure you are in src/03-setup of the books source code
 $ # If you are working with micro:bit v2
-$ cargo-embed --target thumbv7em-none-eabihf
+$ cargo embed --target thumbv7em-none-eabihf
 
 $ # If you are working with micro:bit v1
-$ cargo-embed --target thumbv6m-none-eabi
+$ cargo embed --target thumbv6m-none-eabi
 ```
 
 If everything works correctly cargo-embed should first compile the small example program


### PR DESCRIPTION
Replaces dash with whitespace since the version if the dash is not working.