### PR TITLE
Add rustup target add to verification step and modify chapter 5 slightly

### DIFF
--- a/src/03-setup/verify.md
+++ b/src/03-setup/verify.md
@@ -64,9 +64,11 @@ Next run one of these commands:
 ```
 $ # make sure you are in src/03-setup of the books source code
 $ # If you are working with micro:bit v2
+$ rustup target add thumbv7em-none-eabihf
 $ cargo embed --target thumbv7em-none-eabihf
 
 $ # If you are working with micro:bit v1
+$ rustup target add thumbv6m-none-eabi
 $ cargo embed --target thumbv6m-none-eabi
 ```
 

--- a/src/05-led-roulette/build-it.md
+++ b/src/05-led-roulette/build-it.md
@@ -28,7 +28,11 @@ $ rustup target add thumbv6m-none-eabi
 ```
 
 You only need to do the above step once; `rustup` will re-install a new standard library
-(`rust-std` component) whenever you update your toolchain.
+(`rust-std` component) whenever you update your toolchain. Therefore you can skip this step, if you have already added the necessary target
+while [veryfing your setup].
+
+[veryfing your setup]: ../03-setup/verify.html#verifying-cargo-embed
+
 
 With the `rust-std` component in place you can now cross compile the program using Cargo:
 


### PR DESCRIPTION
Adds `rustup target add *` to chapter 3 verification, but currently leaves the explanation in chapter 5 since the explanation fits better in there (it depends on explanations in ch4).
But if desired I can move everything around.

Fixes #401