### PR TITLE
Use specific chip for micro:bit v1 board.

### DIFF
--- a/microbit/src/03-setup/Embed.toml
+++ b/microbit/src/03-setup/Embed.toml
@@ -5,7 +5,7 @@ protocol = "Swd"
 # v2
 # chip = "nrf52833"
 # v1
-# chip = "nrf51822"
+# chip = "nrf51822_xxAA"
 
 [default.rtt]
 enabled = true

--- a/microbit/src/03-setup/verify.md
+++ b/microbit/src/03-setup/verify.md
@@ -53,7 +53,7 @@ chip variants:
 # v2
 # chip = "nrf52833"
 # v1
-# chip = "nrf51822-xxAA"
+# chip = "nrf51822_xxAA"
 ```
 
 If you are working with the micro:bit v2 board uncomment the first, for the v1

--- a/microbit/src/03-setup/verify.md
+++ b/microbit/src/03-setup/verify.md
@@ -53,7 +53,7 @@ chip variants:
 # v2
 # chip = "nrf52833"
 # v1
-# chip = "nrf51822"
+# chip = "nrf51822-xxAA"
 ```
 
 If you are working with the micro:bit v2 board uncomment the first, for the v1


### PR DESCRIPTION
probe-rs 0.12 changed from accepting generic chip description ("nrf51822")
to requiring specific chip description (e.g. "nrf51822_xxAA").

According to dirbaio on probe-rs matrix "there's three nrf51822 variants
with different flash/ram sizes, AA/AB/AC.
AA is 256k flash, 16k ram, afaik all microbit v1's are AA"

Without this change, when I attempted the `cargo embed` step I got
`Error... Found multiple chips matching 'nrf51822', unable to select a single chip.`