### PR TITLE
Update micro:bit chip descriptions in the book

### DIFF
--- a/microbit/src/03-setup/verify.md
+++ b/microbit/src/03-setup/verify.md
@@ -50,14 +50,12 @@ chip variants:
 
 ```toml
 [default.general]
-# v2
-# chip = "nrf52833"
-# v1
-# chip = "nrf51822_xxAA"
+# chip = "nrf52833" # uncomment this line for micro:bit V2
+# chip = "nrf51822_xxAA" # uncomment this line for micro:bit V1
 ```
 
 If you are working with the micro:bit v2 board uncomment the first, for the v1
-uncomment the second variant.
+uncomment the second line.
 
 Next run one of these commands:
 

--- a/microbit/src/05-led-roulette/it-blinks.md
+++ b/microbit/src/05-led-roulette/it-blinks.md
@@ -50,10 +50,8 @@ since Rust only allows one panic implementation at a time.
 In order to actually see the prints we have to change `Embed.toml` like this:
 ```
 [default.general]
-# v2
-# chip = "nrf52833"
-# v1
-# chip = "nrf51822"
+# chip = "nrf52833" # uncomment this line for micro:bit V2
+# chip = "nrf51822_xxAA" # uncomment this line for micro:bit V1
 
 [default.reset]
 halt_afterwards = false


### PR DESCRIPTION
I forgot editing the book as well in #423.

BTW, I put the chip instructions in one line each so that people are not confused and uncomment also the "v2" comment. I saw somebody asking in the chat about this.