### PR TITLE
Update my-solutions in chapters 7 & 8 to working solutions (issues with heapless)

### DIFF
--- a/microbit/src/07-uart/Cargo.toml
+++ b/microbit/src/07-uart/Cargo.toml
@@ -21,7 +21,7 @@ cortex-m-rt = "0.7.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 nb = "1.0.0"
-heapless = "0.7.7"
+heapless = "0.7.10"
 embedded-hal = "0.2.6"
 
 [features]

--- a/microbit/src/07-uart/my-solution.md
+++ b/microbit/src/07-uart/my-solution.md
@@ -6,7 +6,7 @@
 
 use cortex_m_rt::entry;
 use core::fmt::Write;
-use heapless::{Vec, consts};
+use heapless::Vec;
 use rtt_target::rtt_init_print;
 use panic_rtt_target as _;
 
@@ -56,7 +56,7 @@ fn main() -> ! {
     };
 
     // A buffer with 32 bytes of capacity
-    let mut buffer: Vec<u8, consts::U32> = Vec::new();
+    let mut buffer: Vec<u8, 32> = Vec::new();
 
     loop {
         buffer.clear();

--- a/microbit/src/08-i2c/Cargo.toml
+++ b/microbit/src/08-i2c/Cargo.toml
@@ -21,7 +21,7 @@ cortex-m-rt = "0.7.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 nb = "1.0.0"
-heapless = "0.7.7"
+heapless = "0.7.10"
 lsm303agr = "0.2.2"
 embedded-hal = "0.2.6"
 

--- a/microbit/src/08-i2c/the-challenge.md
+++ b/microbit/src/08-i2c/the-challenge.md
@@ -7,6 +7,6 @@ as well as "accelerometer" and then print the corresponding sensor data
 in response. This time no template code will be provided since all you need
 is already provided in the [UART](../07-uart/index.md) and this chapter. However, here are a few clues:
 
-- You might be interested in `heapless::String` since we are working with strings now
+- You might be interested in `core::str::from_utf8` to convert the bytes in the buffer to a `&str`, since we need to compare with `"magnetometer"` and `"accelerometer"`.
 - You will (obviously) have to read the documentation of the magnetometer API, however
   it's more or less equivalent to the accelerometer one


### PR DESCRIPTION
This pull request adds the `my-solutions.md` of chapter 7 and 8 to work with version 0.7.x of heapless. 

Changes:
- Use `heapless = "0.7.10"` (because why not? I can leave it out if necessary)
- Use const generics with heapless (the `my-solutions.md` got left behind in #432)
- Use `core::str::from_utf8()` instead of `heapless::String::from_utf8()`, because the latter one [got removed](https://github.com/japaric/heapless/blob/3b2bc421a06c083dc71bd66c73f0d98f5976e0cb/CHANGELOG.md?plain=1#L123) in heapless `heapless = "0.7.x"`