### PR TITLE
Change minimal Rust toolchain version

### DIFF
--- a/microbit/src/03-setup/README.md
+++ b/microbit/src/03-setup/README.md
@@ -19,7 +19,7 @@ We'll be referring to all these documents throughout this book:
 We'll use all the tools listed below. Where a minimum version is not specified, any recent version
 should work but we have listed the version we have tested.
 
-- Rust 1.53.0 or a newer toolchain.
+- Rust 1.57.0 or a newer toolchain.
 
 - `gdb-multiarch`. Tested version: 10.2. Other versions will most likely work as well though
   If your distribution/platform does not have `gdb-multiarch` available `arm-none-eabi-gdb`


### PR DESCRIPTION
This pull request updates the minimal Rust toolchain version required for microbit projects.

I had trouble compiling the microbit projects recently. After some research, I found out the `fixed` crate was updated to version `1.12.0` recently, and as stated on the [front page from the crate in crates.io](https://crates.io/crates/fixed), now requires Rust toolchain version 1.57.0 or higher.
This forces to have a Rust toolchain version >= 1.57.0 in order to compile the various projects for microbit v1 and v2.