### PR TITLE
Fix wrong usage of atan2f

### DIFF
--- a/microbit/src/09-led-compass/solution-2.md
+++ b/microbit/src/09-led-compass/solution-2.md
@@ -60,27 +60,27 @@ fn main() -> ! {
         data = calibrated_measurement(data, &calibration);
 
         // use libm's atan2f since this isn't in core yet
-        let theta = atan2f(data.x as f32, data.y as f32);
+        let theta = atan2f(data.y as f32, data.x as f32);
 
         // Figure out the direction based on theta
         let dir = if theta < -7. * PI / 8. {
-            Direction::South
+            Direction::West
         } else if theta < -5. * PI / 8. {
             Direction::SouthWest
         } else if theta < -3. * PI / 8. {
-            Direction::West
+            Direction::South
         } else if theta < -PI / 8. {
-            Direction::NorthWest
+            Direction::SouthEast
         } else if theta < PI / 8. {
-            Direction::North
+            Direction::East
         } else if theta < 3. * PI / 8. {
             Direction::NorthEast
         } else if theta < 5. * PI / 8. {
-            Direction::East
+            Direction::North
         } else if theta < 7. * PI / 8. {
-            Direction::SouthEast
+            Direction::NorthWest
         } else {
-            Direction::South
+            Direction::West
         };
 
         display.show(&mut timer, direction_to_led(dir), 100);

--- a/microbit/src/09-led-compass/take-2.md
+++ b/microbit/src/09-led-compass/take-2.md
@@ -75,7 +75,7 @@ fn main() -> ! {
         data = calibrated_measurement(data, &calibration);
 
         // use libm's atan2f since this isn't in core yet
-        let theta = atan2f(data.x as f32, data.y as f32);
+        let theta = atan2f(data.y as f32, data.x as f32);
 
         // Figure out the direction based on theta
         let dir = Direction::NorthEast;


### PR DESCRIPTION
The arguments of [atan2f](https://docs.rs/libm/latest/libm/fn.atan2f.html) are swapped. The first argument should be `y`, and the second should be `x`. This caused a mismatch between the axis in `take-1.md` and take-2.md`, where in take-1 the north is up, and in take-2 the north is on the right side. Also rotation was flipped because of this.

Swapping the arguments of `atan2f` to match the documentation solves the problem, but the if-else chain needed some adjustment as well. 