### PR TITLE
Update command

### DIFF
--- a/f3discovery/src/05-led-roulette/flash-it.md
+++ b/f3discovery/src/05-led-roulette/flash-it.md
@@ -16,13 +16,13 @@ Make sure the F3 is connected to your computer and run the following commands in
 ## For *nix & MacOS:
 ``` console
 cd /tmp
-openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 ## For Windows **Note**: substitute `C:` for the actual OpenOCD path:
 ```
 cd %TEMP%
-openocd -s C:\share\scripts -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -s C:\share\scripts -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 > **NOTE** Older revisions of the board need to pass slightly different arguments to
@@ -51,12 +51,12 @@ As for OpenOCD, it's software that provides some services like a *GDB server* on
 devices that expose a debugging protocol like SWD or JTAG.
 
 Onto the actual command: those `.cfg` files we are using instruct OpenOCD to look for a ST-LINK USB
-device (`interface/stlink-v2-1.cfg`) and to expect a STM32F3XX microcontroller
+device (`interface/stlink.cfg`) and to expect a STM32F3XX microcontroller
 (`target/stm32f3x.cfg`) to be connected to the ST-LINK.
 
 The OpenOCD output looks like this:
 ``` console
-$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+$ openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
 For bug reports, read


### PR DESCRIPTION
I receive the following error when I follow these instructions:
I receive the following warning when I follow the instructions in Section 5.2: Flash It

```
❯ cd /tmp
openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg

Open On-Chip Debugger 0.11.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
Info : auto-selecting first available session transport "hla_swd". To override use 'transport select <transport>'.
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : clock speed 1000 kHz
Info : STLINK V2J37M26 (API v2) VID:PID 0483:374B
Info : Target voltage: 2.914387
Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f3x.cpu on 3333
Info : Listening on port 3333 for gdb connections
```

I followed the warning and changed the command to 
```
I receive the following warning when I follow the instructions in Section 5.2: Flash It

```
openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
```