### PR TITLE
Add help tip for missing `cargo readobj` subcommand.

### DIFF
--- a/f3discovery/src/05-led-roulette/build-it.md
+++ b/f3discovery/src/05-led-roulette/build-it.md
@@ -123,4 +123,10 @@ ELF Header:
   Section header string table index: 20
   ```
 
+If you get an error like `error: no such subcommand: readobj`, you may need to install `cargo-binutils`:
+``` console
+cargo install cargo-binutils
+rustup component add llvm-tools-preview
+```
+
 Next, we'll flash the program into our microcontroller.


### PR DESCRIPTION
Adds install commands for `carg-binutils` if the reader does not already have it.