### PR TITLE
Added note in the-led-and-delay-abstractions,

### DIFF
--- a/f3discovery/src/05-led-roulette/the-led-and-delay-abstractions.md
+++ b/f3discovery/src/05-led-roulette/the-led-and-delay-abstractions.md
@@ -29,6 +29,10 @@ cargo build
 
 Now we'll run and repeat the flashing procedure as we did in the previous section
 but with the new program. I'll let you type in the `cargo run`, *this will get easier shortly*. :)
+Note: 
+
+Don't forget to start ```openocd``` (debugger) on a seperate terminal or target remote :3333 won't work! 
+
 ``` console
 $ cargo run
     Finished dev [unoptimized + debuginfo] target(s) in 0.01s

--- a/f3discovery/src/05-led-roulette/the-led-and-delay-abstractions.md
+++ b/f3discovery/src/05-led-roulette/the-led-and-delay-abstractions.md
@@ -31,7 +31,7 @@ Now we'll run and repeat the flashing procedure as we did in the previous sectio
 but with the new program. I'll let you type in the `cargo run`, *this will get easier shortly*. :)
 Note: 
 
-Don't forget to start ```openocd``` (debugger) on a seperate terminal or target remote :3333 won't work! 
+Don't forget to start ```openocd``` (debugger) on a separate terminal. Otherwise `target remote :3333` won't work! 
 
 ``` console
 $ cargo run


### PR DESCRIPTION
I got stuck at point 5.4.  trying to enter ```(gdb)``` commands. 

As this is a beginner friendly book, suggesting adding a note that you need debugger active for (gdb) commands. 

e.g. ```(gdb) target remote :3333``` or ```load```
Won't work without openocd being active in a separate window. 