### PR TITLE
Add cargo-embed prerequisite

### DIFF
--- a/microbit/src/03-setup/README.md
+++ b/microbit/src/03-setup/README.md
@@ -76,7 +76,6 @@ cargo-embed 0.11.0
 git commit: crates.io
 ```
 
-
 ### This repository
 
 Since this book also contains some small Rust code bases used in various chapters

--- a/microbit/src/03-setup/README.md
+++ b/microbit/src/03-setup/README.md
@@ -66,6 +66,8 @@ cargo-size 0.3.3
 
 ### `cargo-embed`
 
+In order to install cargo-embed, first install its [prerequisites](https://github.com/probe-rs/cargo-embed#prerequisites). Then install it with cargo:  
+
 ```console
 $ cargo install cargo-embed --vers 0.11.0
 
@@ -73,6 +75,7 @@ $ cargo embed --version
 cargo-embed 0.11.0
 git commit: crates.io
 ```
+
 
 ### This repository
 


### PR DESCRIPTION
Fixes: #479

Given that the prerequisites are relatively complex (depends on the OS), I preferred to link to them instead of trying to give specific instruction for all OSes. Hopefully, that should be enough for most learner, since the prerequisites section is pretty clearly marked