### PR TITLE
Add more details on _y

### DIFF
--- a/microbit/src/05-led-roulette/debug-it.md
+++ b/microbit/src/05-led-roulette/debug-it.md
@@ -109,14 +109,13 @@ At any point you can leave the TUI mode using the following command:
 ```
 
 We are now "on" the `_y = x` statement; that statement hasn't been executed yet. This means that `x`
-is initialized but `_y` is not. Let's inspect those stack/local variables using the `print` command:
+is initialized. Let's inspect the stack/local variable `x` using the `print` command:
 
 ```
 (gdb) print x
 $1 = 42
 (gdb) print &x
 $2 = (*mut i32) 0x20003fe8
-(gdb)
 ```
 
 As expected, `x` contains the value `42`. The command `print &x` prints the address of the variable `x`.


### PR DESCRIPTION
I found
> Let's inspect those stack/local variables

confusing. Indeed, the sentence mentions multiple variables, but a single one was inspected. It was even more surprising because when I entered `print _y`, I got the result 42. (I later understood that it is because the code was run twice, and the value assigned on first run)

For the sake of the consistency, it seems also interesting to mention what the learner would get if they were trying to read `_y`, its address, and maybe also why they could get the correct answer while the value is unitialized.

I considered mentioning that this statement could be checked by switching from 42 to any other number just before running. This would ensure `_y` can not be initialized.