### PR TITLE
Factor out micro:bit LED roulette into turn-key example

### DIFF
--- a/microbit/src/05-led-roulette/Cargo.toml
+++ b/microbit/src/05-led-roulette/Cargo.toml
@@ -19,6 +19,12 @@ panic-halt = "0.2.0"
 #rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 #panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 
+[dev-dependencies]
+# Sneak in dependencies for examples which clash with panic-hal when generating
+# docs with rustdoc.
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
+
 [features]
 v2 = ["microbit-v2"]
 v1 = ["microbit"]

--- a/microbit/src/05-led-roulette/examples/my-solution.rs
+++ b/microbit/src/05-led-roulette/examples/my-solution.rs
@@ -1,0 +1,44 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+use rtt_target::rtt_init_print;
+use panic_rtt_target as _;
+use microbit::{
+    board::Board,
+    display::blocking::Display,
+    hal::Timer,
+};
+
+const PIXELS: [(usize, usize); 16] = [
+    (0,0), (0,1), (0,2), (0,3), (0,4), (1,4), (2,4), (3,4), (4,4),
+    (4,3), (4,2), (4,1), (4,0), (3,0), (2,0), (1,0)
+];
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+
+    let board = Board::take().unwrap();
+    let mut timer = Timer::new(board.TIMER0);
+    let mut display = Display::new(board.display_pins);
+    let mut leds = [
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+    ];
+
+    let mut last_led = (0,0);
+
+    loop {
+        for current_led in PIXELS.iter() {
+            leds[last_led.0][last_led.1] = 0;
+            leds[current_led.0][current_led.1] = 1;
+            display.show(&mut timer, leds, 30);
+            last_led = *current_led;
+        }
+    }
+}

--- a/microbit/src/05-led-roulette/my-solution.md
+++ b/microbit/src/05-led-roulette/my-solution.md
@@ -6,50 +6,7 @@ Here's mine, it's probably one of the simplest (but of course not most
 beautiful) way to generate the required matrix:
 
 ``` rust
-#![deny(unsafe_code)]
-#![no_main]
-#![no_std]
-
-use cortex_m_rt::entry;
-use rtt_target::rtt_init_print;
-use panic_rtt_target as _;
-use microbit::{
-    board::Board,
-    display::blocking::Display,
-    hal::Timer,
-};
-
-const PIXELS: [(usize, usize); 16] = [
-    (0,0), (0,1), (0,2), (0,3), (0,4), (1,4), (2,4), (3,4), (4,4),
-    (4,3), (4,2), (4,1), (4,0), (3,0), (2,0), (1,0)
-];
-
-#[entry]
-fn main() -> ! {
-    rtt_init_print!();
-
-    let board = Board::take().unwrap();
-    let mut timer = Timer::new(board.TIMER0);
-    let mut display = Display::new(board.display_pins);
-    let mut leds = [
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-    ];
-
-    let mut last_led = (0,0);
-
-    loop {
-        for current_led in PIXELS.iter() {
-            leds[last_led.0][last_led.1] = 0;
-            leds[current_led.0][current_led.1] = 1;
-            display.show(&mut timer, leds, 30);
-            last_led = *current_led;
-        }
-    }
-}
+{{#include examples/my-solution.rs}}
 ```
 
 One more thing! Check that your solution also works when compiled in "release" mode:


### PR DESCRIPTION
* Let's lower the bar four young players and have a working reference right out of the repository
* I could be put into action with `cargo-flash` with one of the following invocations:
    ```
    $ cargo flash --example my-solution --features v2 --target thumbv7em-none-eabihf --chip nrf52833_xxAA
    $ cargo flash --example my-solution --features v1 --target thumbv7em-none-eabihf --chip nrf51822_xxAA
    ```