### PR TITLE
Fix link to cargo-embed prerequisites

### DIFF
--- a/microbit/src/03-setup/README.md
+++ b/microbit/src/03-setup/README.md
@@ -66,7 +66,7 @@ cargo-size 0.3.3
 
 ### `cargo-embed`
 
-In order to install cargo-embed, first install its [prerequisites](https://github.com/probe-rs/cargo-embed#prerequisites). Then install it with cargo:  
+In order to install cargo-embed, first install its [prerequisites](https://github.com/probe-rs/probe-rs/blob/master/cargo-embed/README.md#prerequisites). Then install it with cargo:  
 
 ```console
 $ cargo install cargo-embed --vers 0.11.0


### PR DESCRIPTION
Currently, the link pointing to `cargo-embed`'s prerequisites shows a redirection message: "cargo-embed has moved repository".

To ease the process of setting up the development environment, this PR replaces the outdated link by current a one. I'm not entirely sure if the updated link is the best one available, so feel free to substitute a more suitable one.