### PR TITLE
f3discovery: the gdb runner should reference our shared config

### DIFF
--- a/f3discovery/src/.cargo/config.toml
+++ b/f3discovery/src/.cargo/config.toml
@@ -1,3 +1,7 @@
+# default runner starts a GDB sesssion, which requires OpenOCD to be
+# running, e.g.,
+## openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
+# depending on your local GDB, pick one of the following
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb -q -x ../openocd.gdb"
 # runner = "gdb-multiarch -q -x ../openocd.gdb"

--- a/f3discovery/src/.cargo/config.toml
+++ b/f3discovery/src/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.thumbv7em-none-eabihf]
-runner = "arm-none-eabi-gdb -q"
-# runner = "gdb-multiarch -q"
-# runner = "gdb -q"
+runner = "arm-none-eabi-gdb -q -x ../openocd.gdb"
+# runner = "gdb-multiarch -q -x ../openocd.gdb"
+# runner = "gdb -q -x ../openocd.gdb"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]


### PR DESCRIPTION
Let `cargo run` be more seamless and automated in our shared F3discovery cargo configuration.

Make it clear that we expect OpenOCD to be running for this to work.  Yes, this is clarified in the book but a bit of redundant help might be welcome by newbies.