### PR TITLE
Change MacOS instructions to use ARM GCC from mainline cask

### DIFF
--- a/f3discovery/src/03-setup/macos.md
+++ b/f3discovery/src/03-setup/macos.md
@@ -1,20 +1,15 @@
 # macOS
 
-All the tools can be install using [Homebrew]:
+All the tools can be installed using [Homebrew]:
 
 [Homebrew]: http://brew.sh/
 
-Install ArmMbed
 ``` console
-brew tap ArmMbed/homebrew-formulae
-```
-Install the ARM GCC toolchain
-``` console
-brew install arm-none-eabi-gcc
-```
-Install minicom and OpenOCD
-``` console
-brew install minicom openocd
+$ # ARM GCC toolchain
+$ brew install --cask gcc-arm-embedded
+
+$ # Minicom and OpenOCD
+$ brew install minicom openocd
 ```
 
 That's all! Go to the [next section].

--- a/microbit/src/03-setup/macos.md
+++ b/microbit/src/03-setup/macos.md
@@ -5,9 +5,8 @@ All the tools can be installed using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` console
-$ # Arm GCC toolchain
-$ brew tap ArmMbed/homebrew-formulae
-$ brew install arm-none-eabi-gcc
+$ # ARM GCC toolchain
+$ brew install --cask gcc-arm-embedded
 
 $ # Minicom
 $ brew install minicom


### PR DESCRIPTION
https://github.com/ARMmbed/homebrew-formulae has not been updated for more than a year at this point, and does not include native binaries for arm64 Macs.

As far as I can tell, mainline cask uses the same source for binaries but is (more) up to date.

I also took the liberty to update `f3discovery` version of the page to match layout of (more recently updated) `microbit` one — feel free to revert if necessary.

Thank you for your work on the book!!