### PR TITLE
Bump `cargo-embed` version in setup to 0.18.0

### DIFF
--- a/microbit/src/03-setup/README.md
+++ b/microbit/src/03-setup/README.md
@@ -30,7 +30,7 @@ should work but we have listed the version we have tested.
 
 [`cargo-binutils`]: https://github.com/rust-embedded/cargo-binutils
 
-- [`cargo-embed`]. Version 0.11.0 or newer.
+- [`cargo-embed`]. Version 0.18.0 or newer.
 
 [`cargo-embed`]: https://github.com/probe-rs/cargo-embed
 
@@ -66,7 +66,7 @@ cargo-size 0.3.3
 
 ### `cargo-embed`
 
-In order to install cargo-embed, first install its [prerequisites](https://github.com/probe-rs/probe-rs/blob/master/cargo-embed/README.md#prerequisites). Then install it with cargo:  
+In order to install cargo-embed, first install its [prerequisites](https://github.com/probe-rs/probe-rs/blob/master/cargo-embed/README.md#prerequisites). Then install it with cargo:
 
 ```console
 $ cargo install cargo-embed --vers 0.11.0

--- a/microbit/src/05-led-roulette/debug-it.md
+++ b/microbit/src/05-led-roulette/debug-it.md
@@ -101,6 +101,7 @@ Continuing.
 Breakpoint 2, led_roulette::__cortex_m_rt_main () at src/05-led-roulette/src/main.rs:13
 (gdb)
 ```
+
 At any point you can leave the TUI mode using the following command:
 
 ```


### PR DESCRIPTION
Closes #515

I decided to not include a note about checking `cargo-embed` version in case `monitor reset` does not work, version range should be enough imo.