### PR TITLE
Avoid world-writable devices in udev rules

### DIFF
--- a/f3discovery/src/03-setup/linux.md
+++ b/f3discovery/src/03-setup/linux.md
@@ -142,7 +142,7 @@ sudo vi /etc/udev/rules.d/99-openocd.rules
 With the contents:
 ``` text
 # STM32F3DISCOVERY - ST-LINK/V2.1
-ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE:="0666"
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE:="0664"
 ```
 #### For older devices with OPTIONAL USB <-> FT232 based Serial Module
 
@@ -153,7 +153,7 @@ sudo vi /etc/udev/rules.d/99-openocd.rules
 With the contents:
 ``` text
 # FT232 - USB <-> Serial Converter
-ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE:="0666"
+ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE:="0664"
 ```
 
 ### Reload the udev rules with:

--- a/microbit/src/03-setup/linux.md
+++ b/microbit/src/03-setup/linux.md
@@ -65,7 +65,7 @@ $ cat /etc/udev/rules.d/99-microbit.rules
 
 ``` text
 # CMSIS-DAP for microbit
-SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE:="666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE:="664"
 ```
 
 Then reload the udev rules with:


### PR DESCRIPTION
This came out of a discussion in Comprehensive Rust: https://github.com/google/comprehensive-rust/issues/608.

Basically, we've found that it's enough to make the device have `0664` permissions. If you agree with that, it would be nice to update the instructions here so that we can link to them from our course.