### PR TITLE
Update instructions for install gdb on macOS, address issue # 540

### DIFF
--- a/f3discovery/src/03-setup/macos.md
+++ b/f3discovery/src/03-setup/macos.md
@@ -5,8 +5,8 @@ All the tools can be installed using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` console
-$ # ARM GCC toolchain
-$ brew install --cask gcc-arm-embedded
+$ # ARM GCC debugger
+$ brew install arm-none-eabi-gdb
 
 $ # Minicom and OpenOCD
 $ brew install minicom openocd

--- a/microbit/src/03-setup/macos.md
+++ b/microbit/src/03-setup/macos.md
@@ -5,8 +5,8 @@ All the tools can be installed using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` console
-$ # ARM GCC toolchain
-$ brew install --cask gcc-arm-embedded
+$ # ARM GCC debugger
+$ brew install arm-none-eabi-gdb
 
 $ # Minicom
 $ brew install minicom


### PR DESCRIPTION
Older instructions are no longer valid.