### PR TITLE
Update stlink-v2-1.cfg to stlink.cfg

### DIFF
--- a/f3discovery/src/03-setup/verify.md
+++ b/f3discovery/src/03-setup/verify.md
@@ -79,22 +79,21 @@ Two *red* LEDs should turn on right after connecting the USB cable to the board.
 > somewhere else use the `-s /path/to/scripts/` option to specify your install directory.
 
 ``` console
-openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 or
 
 ``` console
-openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
 ```
-
 
 ### Windows
 
 Below the references to `C:\OpenOCD` is the directory where OpenOCD is installed.
 
 ``` console
-openocd -s C:\OpenOCD\share\scripts -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -s C:\OpenOCD\share\scripts -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 > **NOTE** cygwin users have reported problems with the -s flag. If you run into
@@ -102,7 +101,7 @@ openocd -s C:\OpenOCD\share\scripts -f interface/stlink-v2-1.cfg -f target/stm32
 
 cygwin users:
 ``` console
-openocd -f C:\OpenOCD\share\scripts\interface\stlink-v2-1.cfg -f C:\OpenOCD\share\scripts\target\stm32f3x.cfg
+openocd -f C:\OpenOCD\share\scripts\interface\stlink.cfg -f C:\OpenOCD\share\scripts\target\stm32f3x.cfg
 ```
 
 ### All

--- a/f3discovery/src/05-led-roulette/flash-it.md
+++ b/f3discovery/src/05-led-roulette/flash-it.md
@@ -16,13 +16,13 @@ Make sure the F3 is connected to your computer and run the following commands in
 ## For *nix & MacOS:
 ``` console
 cd /tmp
-openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 ## For Windows **Note**: substitute `C:` for the actual OpenOCD path:
 ```
 cd %TEMP%
-openocd -s C:\share\scripts -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -s C:\share\scripts -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 > **NOTE** Older revisions of the board need to pass slightly different arguments to
@@ -51,12 +51,12 @@ As for OpenOCD, it's software that provides some services like a *GDB server* on
 devices that expose a debugging protocol like SWD or JTAG.
 
 Onto the actual command: those `.cfg` files we are using instruct OpenOCD to look for a ST-LINK USB
-device (`interface/stlink-v2-1.cfg`) and to expect a STM32F3XX microcontroller
+device (`interface/stlink.cfg`) and to expect a STM32F3XX microcontroller
 (`target/stm32f3x.cfg`) to be connected to the ST-LINK.
 
 The OpenOCD output looks like this:
 ``` console
-$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+$ openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
 For bug reports, read

--- a/f3discovery/src/appendix/1-general-troubleshooting/README.md
+++ b/f3discovery/src/appendix/1-general-troubleshooting/README.md
@@ -31,7 +31,7 @@ Linux:
   If that works, you can use [these instructions] to make OpenOCD work without
   root privilege.
 - You might be using the wrong interface configuration for your ST-LINK.
-  Try `interface/stlink-v2.cfg` instead of `interface/stlink-v2-1.cfg`.
+  Try `interface/stlink-v2.cfg` or `interface/stlink-v2-1.cfg` instead of `interface/stlink.cfg`.
 
 [these instructions]: ../../03-setup/linux.md#udev-rules
 
@@ -169,7 +169,7 @@ Solution B
 
 All:
 - Send configuration details to OpenOCD when starting it up so that it uses a different port from the default for any of the processes.
-- For example, to do its telnet features on 4441 instead of the default 4444, you would run `openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg -c "telnet_port 4441"`
+- For example, to do its telnet features on 4441 instead of the default 4444, you would run `openocd -f interface/stlink.cfg -f target/stm32f3x.cfg -c "telnet_port 4441"`
 - More details on OpenOCD's Configuration Stage can be found in their [official docs online](http://openocd.org/doc/html/Server-Configuration.html).
 
 


### PR DESCRIPTION
Running openocd w/ stklink-v2-1.cfg, i got a warning:

```
 WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg 
```