### PR TITLE
Clarifying documentation in USART chapter.

### DIFF
--- a/f3discovery/src/11-usart/README.md
+++ b/f3discovery/src/11-usart/README.md
@@ -18,6 +18,9 @@ If you have a newer revision of the board and are using the on-board USB <->
 Serial functionality then the `auxiliary` crate will set pin `PC4` as the TX
 line and pin `PC5` as the RX line.
 
+If you had previously connected the PC4 and PC4 pins in order to test the [loopback functionality](../10-serial-communication/loopbacks.md) in the previous section,
+make sure to remove that wire, or the upcoming serial communication will fail silently.
+
 Everything is already wired on the board so you don't need to wire anything yourself.
 You can move on to the [next section](send-a-single-byte.html).
 


### PR DESCRIPTION
This is a small change. 

I was running into issues with serial comms not coming back from my microcontroller, despite verifying that OpenOCD, itmdump, minicom/PuTTY were working correctly, and the actual pin selection was correct for my board revision. 

It turns out I had misinterpreted this line in 11-usart/README.md:

> Everything is already wired on the board so you don't need to wire anything yourself.

I understood this as a continuation of 10-serial-communication/loopbacks.md, where I had just shorted the PC4 and PC5 pins. I thought "already wired" meant that the PC4-PC5 wire was necessary. This loopback, of course, ends up breaking the Virtual COM Port.

I've added a couple additional lines to ensure others don't run into this same issue, by clarifying the need to remove the wires that were just added. 

This could alternatively be updated in loopbacks.md, by introducing a line such as:
> Ensure you remove the PC4-PC5 wire before proceeding to the next section.

