### PR TITLE
Migrate to probe-rs-tools

### DIFF
--- a/microbit/src/03-setup/README.md
+++ b/microbit/src/03-setup/README.md
@@ -30,7 +30,7 @@ should work but we have listed the version we have tested.
 
 [`cargo-binutils`]: https://github.com/rust-embedded/cargo-binutils
 
-- [`cargo-embed`]. Version 0.18.0 or newer.
+- [`cargo-embed`]. Version 0.24.0 or newer.
 
 [`cargo-embed`]: https://probe.rs/docs/tools/cargo-embed/
 
@@ -69,11 +69,10 @@ cargo-size 0.3.3
 In order to install cargo-embed, first install its [prerequisites](https://probe.rs/docs/getting-started/installation/) (note: these instructions are part of the more general [`probe-rs`](https://probe.rs/) embedded debugging toolkit). Then install it with cargo:
 
 ```console
-$ cargo install cargo-embed --vers 0.18.0
+$ cargo install probe-rs-tools --vers 0.24.0
 
 $ cargo embed --version
-cargo-embed 0.18.0
-git commit: crates.io
+cargo-embed 0.24.0 (git commit: crates.io)
 ```
 
 ### This repository

--- a/microbit/src/03-setup/verify.md
+++ b/microbit/src/03-setup/verify.md
@@ -44,6 +44,47 @@ Furthermore, if you have never flashed another program on to your micro:bit, the
 program the micro:bit ships with should start blinking the red LEDs on its back, you
 can ignore them.
 
+Now let's see if probe-rs, and by extensions cargo-embed can see your micro:bit, you can do this by running the following command.
+
+``` console
+$ probe-rs list
+The following debug probes were found:
+[0]: BBC micro:bit CMSIS-DAP -- 0d28:0204:990636020005282030f57fa14252d446000000006e052820 (CMSIS-DAP)
+```
+
+Or if you want more information about the micro:bits debug capabilities then you can run:
+
+``` console
+$ probe-rs info
+Probing target via JTAG
+
+Error identifying target using protocol JTAG: The probe does not support the JTAG protocol.
+
+Probing target via SWD
+
+ARM Chip with debug port Default:
+Debug Port: DPv1, DP Designer: ARM Ltd
+├── 0 MemoryAP
+│   └── ROM Table (Class 1), Designer: Nordic VLSI ASA
+│       ├── Cortex-M4 SCS   (Generic IP component)
+│       │   └── CPUID
+│       │       ├── IMPLEMENTER: ARM Ltd
+│       │       ├── VARIANT: 0
+│       │       ├── PARTNO: Cortex-M4
+│       │       └── REVISION: 1
+│       ├── Cortex-M3 DWT   (Generic IP component)
+│       ├── Cortex-M3 FBP   (Generic IP component)
+│       ├── Cortex-M3 ITM   (Generic IP component)
+│       ├── Cortex-M4 TPIU  (Coresight Component)
+│       └── Cortex-M4 ETM   (Coresight Component)
+└── 1 Unknown AP (Designer: Nordic VLSI ASA, Class: Undefined, Type: 0x0, Variant: 0x0, Revision: 0x0)
+
+
+Debugging RISC-V targets over SWD is not supported. For these targets, JTAG is the only supported protocol. RISC-V specific information cannot be printed.
+Debugging Xtensa targets over SWD is not supported. For these targets, JTAG is the only supported protocol. Xtensa specific information cannot be printed.
+
+```
+
 Next up you will have to modify `Embed.toml` in the `src/03-setup` directory of the
 book's source code. In the `default.general` section you will find two commented out
 chip variants:


### PR DESCRIPTION
Cargo-embed by it self has been deprecated, and has been included in probe-rs instead, update the documentation to install `probe-rs-tools` instead of `cargo-embed`, and added some command line tests to show how to test if probe-rs can see the micro:bit
