### PR TITLE
Update udev rules 

### DIFF
--- a/microbit/src/03-setup/linux.md
+++ b/microbit/src/03-setup/linux.md
@@ -60,21 +60,30 @@ These rules let you use USB devices like the micro:bit without root privilege, i
 Create this file in `/etc/udev/rules.d` with the content shown below.
 
 ``` console
-$ cat /etc/udev/rules.d/99-microbit.rules
+$ cat /etc/udev/rules.d/69-microbit.rules
 ```
 
 ``` text
 # CMSIS-DAP for microbit
-SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE:="666"
+
+ACTION!="add|change", GOTO="microbit_rules_end"
+
+SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", TAG+="uaccess"
+
+LABEL="microbit_rules_end"
 ```
 
 Then reload the udev rules with:
 
 ``` console
-$ sudo udevadm control --reload-rules
+$ sudo udevadm control --reload
 ```
 
-If you had any board plugged to your computer, unplug them and then plug them in again.
+If you had any board plugged to your computer, unplug them and then plug them in again, or run the following command.
+
+``` console
+$ sudo udevadm trigger
+```
 
 Now, go to the [next section].
 

--- a/microbit/src/03-setup/verify.md
+++ b/microbit/src/03-setup/verify.md
@@ -18,20 +18,36 @@ $ # ^^^        ^^^
 ```
 
 In my case, the micro:bit got connected to the bus #1 and got enumerated as the device #65. This means the
-file `/dev/bus/usb/001/065` *is* the micro:bit. Let's check its permissions:
+file `/dev/bus/usb/001/065` *is* the micro:bit. Let's check the file permissions:
 
 ``` console
 $ ls -l /dev/bus/usb/001/065
-crw-rw-rw-. 1 root root 189, 64 Sep  5 14:27 /dev/bus/usb/001/065
+crw-rw-r--+ 1 nobody nobody 189, 64 Sep  5 14:27 /dev/bus/usb/001/065
 ```
 
-The permissions should be `crw-rw-rw-`. If it's not ... then check your [udev
+The permissions should be `crw-rw-r--+`, note the `+` at the end, then see your access rights by running the following command.
+
+``` console
+$ getfacl /dev/bus/usb/001/065
+getfacl: Removing leadin '/' from absolute path names
+# file: dev/bus/usb/001/065
+# owner: nobody
+# group: nobody
+user::rw-
+user:<YOUR-USER-NAME>:rw-
+group::rw-
+mask::rw-
+other::r-
+```
+
+You should see your username in the list above with the `rw-` permissions, if not ... then check your [udev
 rules] and try re-loading them with:
 
 [udev rules]: linux.md#udev-rules
 
 ``` console
-$ sudo udevadm control --reload-rules
+$ sudo udevadm control --reload
+$ sudo udevadm trigger
 ```
 
 # All


### PR DESCRIPTION
Update udev rules to fit better with modern systems.

Updated the udev rules to use the `uaccess` tag instead of the `MODE` and `GROUP` modifiers, as that is deprecated.

Renamed the udev rule file to start with 69 instead of 99, so it gets loaded before user access rules are loaded for `uaccess` permissions, which is run in 73-seat-late.rules (provided by systemd).

Added text showing how to test for these `uaccess` permissions.

Attached the udev rules file: [69-microbit.txt](https://github.com/user-attachments/files/15748644/69-microbit.txt)