### PR TITLE
 MacOS install instructions - lsusb

### DIFF
--- a/microbit/src/03-setup/macos.md
+++ b/microbit/src/03-setup/macos.md
@@ -10,6 +10,9 @@ $ brew install arm-none-eabi-gdb
 
 $ # Minicom
 $ brew install minicom
+
+$ # lsusb (list connected USB devices)
+$ brew install lsusb
 ```
 
 That's all! Go to the [next section].


### PR DESCRIPTION
I noticed while going through the discovery book (that uses a micro:bit controller), that I could not run the `lsusb` command provided after the setup section. It looks like on MacOS, this bin isn't there by default and also needs to be installed with `brew`, so this PR adds that command to the MacOS-specific installation steps.