### PR TITLE
added instructions for finding Meta key on MacOS

### DIFF
--- a/microbit/src/06-serial-communication/minicom-on-macos.md
+++ b/microbit/src/06-serial-communication/minicom-on-macos.md
@@ -1,0 +1,10 @@
+# Minicom on macOS
+
+### Finding Your Command Key
+
+```shell
+$ # start minicom in setup mode
+$ minicom -s
+```
+1. Select `Keyboard and Misc Functions`
+2. Look at the first option `A - Command key is` 

--- a/microbit/src/06-serial-communication/nix-tooling.md
+++ b/microbit/src/06-serial-communication/nix-tooling.md
@@ -91,3 +91,5 @@ Mac, the shortcuts start with the `Meta` key. Some useful commands below:
 - `Ctrl+A` + `Q`. Quit with no reset
 
 > **NOTE** Mac users: In the above commands, replace `Ctrl+A` with `Meta`.
+
+[Can't find the Meta key?](minicom-on-macos.md)

--- a/microbit/src/SUMMARY.md
+++ b/microbit/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [Serial communication](06-serial-communication/README.md)
     - [\*nix tooling](06-serial-communication/nix-tooling.md)
     - [Windows tooling](06-serial-communication/windows-tooling.md)
+    - [Minicom on macOS](06-serial-communication/minicom-on-macos.md)
 - [UART](07-uart/README.md)
     - [Send a single byte](07-uart/send-a-single-byte.md)
     - [Send a string](07-uart/send-a-string.md)


### PR DESCRIPTION
### The Issue
I had trouble using **minicom** because it's not obvious which keyboard key corresponds to **Meta.** I tried various keys such as CNTRL, CMD, & Option but nothing worked.

### Solution
I found that the Meta key is **ESC**  by running minicom in setup mode using `$ minicom -s`

### Changes
* I created a new page called `macos-meta.md`
* I added a link to it at the end of `nix-tooling.md`