### PR TITLE
ignore .idea everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 Cargo.lock
 book/
 target/
-/.idea
+.idea


### PR DESCRIPTION
Tiny QoL PR. 

There's no real reason (that I can see) to only ignore `.idea` in the repo root. If you only have a Microbit for example, you're going to work in the appropriate subdirectory and any `.idea` directory that gets created is just clutter.