### PR TITLE
Update nix-tooling.md

### DIFF
--- a/microbit/src/06-serial-communication/nix-tooling.md
+++ b/microbit/src/06-serial-communication/nix-tooling.md
@@ -7,7 +7,7 @@ should see a new TTY device appear in `/dev`.
 
 ``` console
 $ # Linux
-$ dmesg | tail | grep -i tty
+$ dmesg | grep -i tty
 [63712.446286] cdc_acm 1-1.7:1.1: ttyACM0: USB ACM device
 ```
 


### PR DESCRIPTION
Fix the command, tail for some reason results in empty result.

```bash
    ~  sudo dmesg | grep -i tty                                     PIPE|127 ✘ 
[    0.008385] ACPI: SSDT 0x0000000055BD1000 000FC2 (v02 DELL\x TbtTypeC 00000000 INTL 20160527)
[    0.118757] printk: console [tty0] enabled
[    9.144579] systemd[1]: Created slice Slice /system/getty.
[   31.236067] Bluetooth: RFCOMM TTY layer initialized
[  507.736831] cdc_acm 1-4:1.1: ttyACM0: USB ACM device
    ~  sudo dmesg | tail | grep -i tty                                       ✔ 
    ~  
```