### PR TITLE
rename the `author` field to `authors` in book.toml

### DIFF
--- a/f3discovery/book.toml
+++ b/f3discovery/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "Discovery"
 description = "Discover the world of microcontrollers through Rust"
-author = "Rust Embedded Resources Team"
+authors = ["Rust Embedded Resources Team"]
 language = "en"
 
 [output.html]

--- a/microbit/book.toml
+++ b/microbit/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "Discovery"
 description = "Discover the world of microcontrollers through Rust"
-author = "Rust Embedded Resources Team"
+authors = ["Rust Embedded Resources Team"]
 language = "en"
 
 [output.html]


### PR DESCRIPTION
See the [mdbook documentation](https://rust-lang.github.io/mdBook/format/configuration/general.html)
Apparently the `author` was field was [incorrect documentation](https://github.com/rust-lang/mdBook/issues/2623)